### PR TITLE
Add prepare script so git-dependency installs build the UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test:watch": "vitest",
     "test:watchdog": "vitest run tests/server/watchdog.test.js tests/server/watchdog-db.test.js tests/server/routes-watchdog.test.js",
     "test:coverage": "vitest run --coverage",
-    "prepack": "npm run build:ui"
+    "prepack": "npm run build:ui",
+    "prepare": "npm run build:ui"
   },
   "dependencies": {
     "express": "^4.21.0",


### PR DESCRIPTION
npm skips prepack for git-URL installs, so the UI build artifacts (lib/public/dist, tailwind.generated.css, css/vendor) never built and the setup UI rendered blank. 'prepare' runs for git deps and rebuilds them.