### PR TITLE
Support git-based deployment of AlphaClaw

### DIFF
--- a/bin/alphaclaw.js
+++ b/bin/alphaclaw.js
@@ -20,6 +20,7 @@ const {
   restoreMissingOpenclawConfigFromRemote,
 } = require("../lib/cli/openclaw-config-restore");
 const { buildSecretReplacements } = require("../lib/server/helpers");
+const { resolveSelfDependency } = require("../lib/server/self-dependency");
 const {
   migrateManagedInternalFiles,
 } = require("../lib/server/internal-files-migration");
@@ -170,29 +171,34 @@ console.log(`[alphaclaw] Root directory: ${rootDir}`);
 // from the fresh container using the persistent volume marker.
 const pendingUpdateMarker = path.join(rootDir, ".alphaclaw-update-pending");
 if (fs.existsSync(pendingUpdateMarker)) {
-  console.log(
-    "[alphaclaw] Pending update detected, installing @chrysb/alphaclaw@latest...",
-  );
-  const alphaPkgRoot = path.resolve(__dirname, "..");
-  const nmIndex = alphaPkgRoot.lastIndexOf(
-    `${path.sep}node_modules${path.sep}`,
-  );
-  const installDir =
-    nmIndex >= 0 ? alphaPkgRoot.slice(0, nmIndex) : alphaPkgRoot;
-  try {
-    execSync(
-      "npm install @chrysb/alphaclaw@latest --omit=dev --prefer-online",
-      {
-        cwd: installDir,
-        stdio: "inherit",
-        timeout: 180000,
-      },
+  const selfDep = resolveSelfDependency({ fsImpl: fs });
+  if (selfDep.isGit) {
+    // Git-based installs update by redeploying (which reinstalls from the pinned
+    // ref), not by `npm install <pkg>@latest`. Clear the marker and move on.
+    console.log(
+      "[alphaclaw] Pending update marker found, but this install is git-based; updates apply on redeploy. Skipping npm install.",
     );
     fs.unlinkSync(pendingUpdateMarker);
-    console.log("[alphaclaw] Update applied successfully");
-  } catch (e) {
-    console.log(`[alphaclaw] Update install failed: ${e.message}`);
-    fs.unlinkSync(pendingUpdateMarker);
+  } else {
+    const selfUpdatePackageName = selfDep.key || "alphaclaw";
+    console.log(
+      `[alphaclaw] Pending update detected, installing ${selfUpdatePackageName}@latest...`,
+    );
+    try {
+      execSync(
+        `npm install ${selfUpdatePackageName}@latest --omit=dev --prefer-online`,
+        {
+          cwd: selfDep.installDir,
+          stdio: "inherit",
+          timeout: 180000,
+        },
+      );
+      fs.unlinkSync(pendingUpdateMarker);
+      console.log("[alphaclaw] Update applied successfully");
+    } catch (e) {
+      console.log(`[alphaclaw] Update install failed: ${e.message}`);
+      fs.unlinkSync(pendingUpdateMarker);
+    }
   }
 }
 

--- a/lib/server/alphaclaw-version.js
+++ b/lib/server/alphaclaw-version.js
@@ -14,6 +14,10 @@ const {
   normalizeOpenclawVersion,
   resolveGithubRepoUrl,
 } = require("./helpers");
+const {
+  resolveSelfDependency,
+  looksLikeGitDependency,
+} = require("./self-dependency");
 
 const kGithubApiBaseUrl = "https://api.github.com/repos";
 const kGithubRawBaseUrl = "https://raw.githubusercontent.com";
@@ -21,7 +25,7 @@ const kDefaultTemplateBranch = "main";
 const kRailwayTemplateRepoUrl =
   "https://github.com/chrysb/openclaw-railway-template.git";
 const kRenderTemplateRepoUrl =
-  "https://github.com/chrysb/openclaw-render-template.git";
+  "https://github.com/garrytan/openclaw-render-template.git";
 const kApexTemplateRepoUrl =
   "https://github.com/chrysb/openclaw-apex-template.git";
 
@@ -91,10 +95,18 @@ const buildGithubHeaders = ({ env = process.env, accept = "application/json" } =
   return headers;
 };
 
-const extractTemplateVersions = (pkg) => ({
-  latestVersion: normalizeVersion(pkg?.dependencies?.["@chrysb/alphaclaw"]),
-  latestOpenclawVersion: normalizeOpenclawVersion(pkg?.dependencies?.openclaw),
-});
+const extractTemplateVersions = (pkg) => {
+  const alphaclawSpec =
+    pkg?.dependencies?.["alphaclaw"] || pkg?.dependencies?.["@chrysb/alphaclaw"];
+  return {
+    // A git-pinned template has no semver to compare against — report null so we
+    // never surface a bogus "update available" from a git URL string.
+    latestVersion: looksLikeGitDependency(alphaclawSpec)
+      ? null
+      : normalizeVersion(alphaclawSpec),
+    latestOpenclawVersion: normalizeOpenclawVersion(pkg?.dependencies?.openclaw),
+  };
+};
 
 const fetchLatestVersionFromRegistry = async ({ fetchImpl, version = null }) => {
   if (typeof fetchImpl !== "function") {
@@ -343,12 +355,33 @@ const detectUpdateStrategy = ({
     });
   }
 
+  // Git-based installs (e.g. `"alphaclaw": "git+https://github.com/<owner>/alphaclaw.git#main"`)
+  // can't be updated by `npm install <pkg>@latest` from the registry — updates come
+  // from pulling the source and reinstalling/redeploying. Keep the in-place npm
+  // self-update only when AlphaClaw is pinned to an npm version.
+  const selfDep = resolveSelfDependency({ fsImpl });
+  if (selfDep.isGit) {
+    return createUpdateStrategy({
+      action: "instructions",
+      provider: "git",
+      label: "Git source",
+      description:
+        "This AlphaClaw is installed from a git repository. Update by pulling the latest commit of your source repo and reinstalling (or redeploying), then restart AlphaClaw.",
+      steps: [
+        "Pull the latest commit of your AlphaClaw source repository",
+        "Reinstall dependencies so the new version is built (npm install)",
+        "Restart AlphaClaw to load the update",
+      ],
+      primaryActionLabel: "Done",
+    });
+  }
+
+  const selfUpdatePackageName = selfDep.key || "alphaclaw";
   return createUpdateStrategy({
     action: "self-update",
     provider: "self-hosted",
     label: "This install",
-    description:
-      "This will install the latest @chrysb/alphaclaw package in place and restart AlphaClaw.",
+    description: `This will install the latest ${selfUpdatePackageName} package in place and restart AlphaClaw.`,
     steps: [
       "AlphaClaw will install the latest published package in place",
       "The process will restart after the new files are copied into node_modules",
@@ -451,7 +484,9 @@ const createAlphaclawVersionService = ({
 
   const installLatestAlphaclaw = () =>
     new Promise((resolve, reject) => {
-      const installDir = findInstallDir(fsImpl);
+      const selfDep = resolveSelfDependency({ fsImpl });
+      const installDir = selfDep.installDir;
+      const selfUpdatePackageName = selfDep.key || "alphaclaw";
       const tmpDir = fsImpl.mkdtempSync(path.join(os.tmpdir(), "alphaclaw-update-"));
 
       const cleanup = () => {
@@ -464,7 +499,7 @@ const createAlphaclawVersionService = ({
         path.join(tmpDir, "package.json"),
         JSON.stringify({
           private: true,
-          dependencies: { "@chrysb/alphaclaw": "latest" },
+          dependencies: { [selfUpdatePackageName]: "latest" },
         }),
       );
 
@@ -476,7 +511,7 @@ const createAlphaclawVersionService = ({
       };
 
       console.log(
-        `[alphaclaw] Running: npm install @chrysb/alphaclaw@latest in temp dir (target: ${installDir})`,
+        `[alphaclaw] Running: npm install ${selfUpdatePackageName}@latest in temp dir (target: ${installDir})`,
       );
       childProcess.exec(
         "npm install --omit=dev --prefer-online --package-lock=false",
@@ -494,7 +529,7 @@ const createAlphaclawVersionService = ({
             cleanup();
             return reject(
               new Error(
-                message || "Failed to install @chrysb/alphaclaw@latest",
+                message || `Failed to install ${selfUpdatePackageName}@latest`,
               ),
             );
           }
@@ -616,6 +651,12 @@ const createAlphaclawVersionService = ({
   const getVersionStatus = async (refresh) => {
     const strategy = detectUpdateStrategy({ env, fsImpl });
     try {
+      if (strategy.provider === "git") {
+        // Git-sourced installs have no npm registry or template version to compare
+        // against — updates come from redeploying the pinned ref. Report current
+        // state without a remote version check.
+        return buildVersionStatus({ strategy });
+      }
       if (strategy.templateRepoUrl) {
         const status = await readTemplateStatus({
           repoUrl: strategy.templateRepoUrl,
@@ -717,35 +758,6 @@ const createAlphaclawVersionService = ({
     updateAlphaclaw,
     restartProcess,
   };
-};
-
-const findInstallDir = (fsImpl) => {
-  let dir = kNpmPackageRoot;
-  while (dir !== path.dirname(dir)) {
-    const parent = path.dirname(dir);
-    if (
-      path.basename(parent) === "node_modules" ||
-      parent.includes(`${path.sep}node_modules${path.sep}`)
-    ) {
-      dir = parent;
-      continue;
-    }
-    const pkgPath = path.join(parent, "package.json");
-    if (fsImpl.existsSync(pkgPath)) {
-      try {
-        const pkg = JSON.parse(fsImpl.readFileSync(pkgPath, "utf8"));
-        if (
-          pkg.dependencies?.["@chrysb/alphaclaw"] ||
-          pkg.devDependencies?.["@chrysb/alphaclaw"] ||
-          pkg.optionalDependencies?.["@chrysb/alphaclaw"]
-        ) {
-          return parent;
-        }
-      } catch {}
-    }
-    dir = parent;
-  }
-  return kNpmPackageRoot;
 };
 
 module.exports = {

--- a/lib/server/constants.js
+++ b/lib/server/constants.js
@@ -211,7 +211,7 @@ const kOpenclawUpdateCopyTimeoutMs = 5 * 60 * 1000;
 const kOpenclawRegistryUrl = "https://registry.npmjs.org/openclaw";
 const kAlphaclawRegistryUrl = "https://registry.npmjs.org/@chrysb%2falphaclaw";
 const kAlphaclawGithubReleasesBaseUrl =
-  "https://api.github.com/repos/chrysb/alphaclaw/releases";
+  "https://api.github.com/repos/garrytan/alphaclaw/releases";
 const kAppDir = kNpmPackageRoot;
 const kMaxPayloadBytes = parsePositiveInt(process.env.WEBHOOK_LOG_MAX_BYTES, 50 * 1024);
 const kWebhookPruneDays = parsePositiveInt(process.env.WEBHOOK_LOG_RETENTION_DAYS, 30);

--- a/lib/server/openclaw-version.js
+++ b/lib/server/openclaw-version.js
@@ -10,6 +10,7 @@ const {
 } = require("./constants");
 const { normalizeOpenclawVersion } = require("./helpers");
 const { parseJsonObjectFromNoisyOutput } = require("./utils/json");
+const { resolveSelfDependency } = require("./self-dependency");
 
 const createOpenclawVersionService = ({
   gatewayEnv,
@@ -88,35 +89,10 @@ const createOpenclawVersionService = ({
     }
   };
 
-  const findInstallDir = () => {
-    // Resolve the consumer app root (for example /app in Docker), not this package directory.
-    let dir = kNpmPackageRoot;
-    while (dir !== path.dirname(dir)) {
-      const parent = path.dirname(dir);
-      if (
-        path.basename(parent) === "node_modules" ||
-        parent.includes(`${path.sep}node_modules${path.sep}`)
-      ) {
-        dir = parent;
-        continue;
-      }
-      const pkgPath = path.join(parent, "package.json");
-      if (fs.existsSync(pkgPath)) {
-        try {
-          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
-          if (
-            pkg.dependencies?.["@chrysb/alphaclaw"] ||
-            pkg.devDependencies?.["@chrysb/alphaclaw"] ||
-            pkg.optionalDependencies?.["@chrysb/alphaclaw"]
-          ) {
-            return parent;
-          }
-        } catch {}
-      }
-      dir = parent;
-    }
-    return kNpmPackageRoot;
-  };
+  // Resolve the consumer app root (for example /app in Docker), not this package
+  // directory. Matches AlphaClaw under either the `alphaclaw` alias (git installs)
+  // or the `@chrysb/alphaclaw` npm scope.
+  const findInstallDir = () => resolveSelfDependency({ fsImpl: fs }).installDir;
 
   // Install to a temp directory, then copy into the real node_modules.
   // Running `npm install` directly in the app dir causes EBUSY on Docker

--- a/lib/server/self-dependency.js
+++ b/lib/server/self-dependency.js
@@ -1,0 +1,75 @@
+const fs = require("fs");
+const path = require("path");
+const { kNpmPackageRoot } = require("./constants");
+
+// AlphaClaw may be consumed under different dependency keys: the published npm
+// scope (`@chrysb/alphaclaw`) or a plain alias used by git-based deployments
+// (`alphaclaw`, e.g. `"alphaclaw": "git+https://github.com/<owner>/alphaclaw.git#main"`).
+// Check the alias first so git deployments resolve correctly.
+const kSelfDependencyKeys = ["alphaclaw", "@chrysb/alphaclaw"];
+
+// A dependency spec points at a git source (rather than an npm version/range)
+// when it uses a git protocol/shorthand or otherwise references a git host.
+const looksLikeGitDependency = (spec) => {
+  const value = String(spec || "").trim();
+  if (!value) return false;
+  return (
+    /^(git\+|github:|gitlab:|bitbucket:|gist:|git:|git@|ssh:)/i.test(value) ||
+    /\.git($|#)/i.test(value) ||
+    /github\.com/i.test(value)
+  );
+};
+
+const readDependencySpec = (pkg, key) =>
+  pkg?.dependencies?.[key] ||
+  pkg?.devDependencies?.[key] ||
+  pkg?.optionalDependencies?.[key] ||
+  null;
+
+// Find the consumer app root (e.g. /app in Docker) — the nearest ancestor
+// package.json that declares AlphaClaw as a dependency — and report how it is
+// pinned. Falls back to the AlphaClaw package root with no dependency info.
+const resolveSelfDependency = ({ fsImpl = fs, startDir = kNpmPackageRoot } = {}) => {
+  let dir = startDir;
+  while (dir !== path.dirname(dir)) {
+    const parent = path.dirname(dir);
+    if (
+      path.basename(parent) === "node_modules" ||
+      parent.includes(`${path.sep}node_modules${path.sep}`)
+    ) {
+      dir = parent;
+      continue;
+    }
+    const pkgPath = path.join(parent, "package.json");
+    if (fsImpl.existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(fsImpl.readFileSync(pkgPath, "utf8"));
+        for (const key of kSelfDependencyKeys) {
+          const spec = readDependencySpec(pkg, key);
+          if (spec) {
+            return {
+              installDir: parent,
+              key,
+              spec,
+              isGit: looksLikeGitDependency(spec),
+            };
+          }
+        }
+      } catch {}
+    }
+    dir = parent;
+  }
+  return { installDir: kNpmPackageRoot, key: null, spec: null, isGit: false };
+};
+
+// Resolve just the install dir (consumer app root) — preserves the prior
+// findInstallDir() contract used by the OpenClaw/AlphaClaw self-updaters.
+const findInstallDir = (fsImpl = fs) =>
+  resolveSelfDependency({ fsImpl }).installDir;
+
+module.exports = {
+  kSelfDependencyKeys,
+  looksLikeGitDependency,
+  resolveSelfDependency,
+  findInstallDir,
+};

--- a/lib/server/usage-tracker-config.js
+++ b/lib/server/usage-tracker-config.js
@@ -7,6 +7,10 @@ const kUsageTrackerPluginPath = path.resolve(
   "plugin",
   "usage-tracker",
 );
+// Matches any `.../lib/plugin/usage-tracker` load path regardless of where the
+// AlphaClaw package was installed (npm scope dir, git alias dir, version bumps).
+const kUsageTrackerPluginPathPattern = /[\\/]plugin[\\/]usage-tracker[\\/]?$/;
+
 const kConversationAccessHookPolicyKey = "allowConversationAccess";
 const kChannelPluginIds = ["telegram", "discord", "slack", "whatsapp"];
 const kDefaultDiscordGroupPolicy = "disabled";
@@ -72,6 +76,24 @@ const ensureUsageTrackerPluginEntry = (cfg = {}) => {
   return JSON.stringify(cfg) !== before;
 };
 
+// Remove usage-tracker plugin paths left behind by a previous install location
+// (e.g. a prior `@chrysb/alphaclaw` npm install at `/app/node_modules/@chrysb/alphaclaw/...`
+// after switching to a git dependency installed at `/app/node_modules/alphaclaw/...`).
+// Only the current `__dirname`-resolved path is valid; any other entry pointing at a
+// `.../plugin/usage-tracker` dir is dead and makes OpenClaw reject the whole config.
+const pruneStaleUsageTrackerPaths = (cfg = {}) => {
+  ensurePluginsShell(cfg);
+  const paths = cfg.plugins.load.paths;
+  const filtered = paths.filter(
+    (entry) =>
+      entry === kUsageTrackerPluginPath ||
+      !kUsageTrackerPluginPathPattern.test(String(entry || "")),
+  );
+  if (filtered.length === paths.length) return false;
+  cfg.plugins.load.paths = filtered;
+  return true;
+};
+
 const hasDiscordGuildAllowlist = (discordConfig = {}) => {
   const guilds = discordConfig.guilds;
   return !!guilds && typeof guilds === "object" && Object.keys(guilds).length > 0;
@@ -123,7 +145,10 @@ const ensureUsageTrackerPluginConfig = ({ fsModule, openclawDir }) => {
     openclawDir,
     fallback: {},
   });
-  const changed = reconcileManagedPluginConfig(cfg);
+  // Migrate configs written by a previous install location before reconciling,
+  // so the canonical path is the only usage-tracker entry that remains.
+  const prunedStale = pruneStaleUsageTrackerPaths(cfg);
+  const changed = reconcileManagedPluginConfig(cfg) || prunedStale;
   if (!changed) return false;
   writeOpenclawConfig({
     fsModule,
@@ -139,6 +164,7 @@ module.exports = {
   kDefaultDiscordGroupPolicy,
   ensurePluginsShell,
   ensurePluginAllowed,
+  pruneStaleUsageTrackerPaths,
   ensureUsageTrackerPluginEntry,
   reconcileDiscordGroupPolicy,
   reconcileEnabledChannelPlugins,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@chrysb/alphaclaw",
+  "name": "alphaclaw",
   "version": "0.9.18",
   "publishConfig": {
     "access": "public"

--- a/tests/server/alphaclaw-version.test.js
+++ b/tests/server/alphaclaw-version.test.js
@@ -97,6 +97,58 @@ describe("server/alphaclaw-version", () => {
     );
   });
 
+  it("returns git-source instructions and skips the npm registry for git installs", async () => {
+    const fetchMock = vi.fn();
+    const gitPkg = JSON.stringify({
+      dependencies: {
+        alphaclaw: "git+https://github.com/garrytan/alphaclaw.git#main",
+      },
+    });
+    const { service } = createService({
+      env: {},
+      fetchMock,
+      fsImpl: {
+        ...fs,
+        // /.dockerenv absent (so we reach the self-hosted fallback) but the
+        // consumer package.json is found by resolveSelfDependency.
+        existsSync: vi.fn((p) => String(p).endsWith("package.json")),
+        readFileSync: vi.fn(() => gitPkg),
+      },
+    });
+
+    const status = await service.getVersionStatus(false);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(status.hasUpdate).toBe(false);
+    expect(status.updateStrategy).toEqual(
+      expect.objectContaining({ action: "instructions", provider: "git" }),
+    );
+  });
+
+  it("refuses an in-place update for git installs", async () => {
+    const gitPkg = JSON.stringify({
+      dependencies: {
+        alphaclaw: "git+https://github.com/garrytan/alphaclaw.git#main",
+      },
+    });
+    const execMock = vi.fn();
+    const { service } = createService({
+      env: {},
+      execMock,
+      fsImpl: {
+        ...fs,
+        existsSync: vi.fn((p) => String(p).endsWith("package.json")),
+        readFileSync: vi.fn(() => gitPkg),
+      },
+    });
+
+    const result = await service.updateAlphaclaw();
+
+    expect(result.status).toBe(409);
+    expect(result.body.ok).toBe(false);
+    expect(execMock).not.toHaveBeenCalled();
+  });
+
   it("returns template-managed status for railway deployments", async () => {
     const fetchMock = vi.fn(async (url) => {
       expect(url).toContain(

--- a/tests/server/self-dependency.test.js
+++ b/tests/server/self-dependency.test.js
@@ -1,0 +1,88 @@
+const fs = require("fs");
+
+const {
+  looksLikeGitDependency,
+  resolveSelfDependency,
+} = require("../../lib/server/self-dependency");
+
+describe("server/self-dependency", () => {
+  describe("looksLikeGitDependency", () => {
+    it("flags git URL specs", () => {
+      for (const spec of [
+        "git+https://github.com/garrytan/alphaclaw.git#main",
+        "github:garrytan/alphaclaw#main",
+        "git+ssh://git@github.com/garrytan/alphaclaw.git",
+        "https://github.com/garrytan/alphaclaw",
+        "git://example.com/alphaclaw.git",
+      ]) {
+        expect(looksLikeGitDependency(spec)).toBe(true);
+      }
+    });
+
+    it("does not flag npm version specs", () => {
+      for (const spec of ["0.9.18", "^0.9.0", "latest", "~1.2.3", ""]) {
+        expect(looksLikeGitDependency(spec)).toBe(false);
+      }
+    });
+  });
+
+  describe("resolveSelfDependency", () => {
+    const makeFs = (pkgByPath) => ({
+      ...fs,
+      existsSync: (p) => Object.prototype.hasOwnProperty.call(pkgByPath, p),
+      readFileSync: (p) => {
+        if (!pkgByPath[p]) throw new Error(`no such file: ${p}`);
+        return JSON.stringify(pkgByPath[p]);
+      },
+    });
+
+    it("resolves a git-pinned consumer dependency under the alphaclaw alias", () => {
+      const fsImpl = makeFs({
+        "/app/package.json": {
+          dependencies: {
+            alphaclaw: "git+https://github.com/garrytan/alphaclaw.git#main",
+          },
+        },
+      });
+      const result = resolveSelfDependency({
+        fsImpl,
+        startDir: "/app/node_modules/alphaclaw/lib/server",
+      });
+      expect(result).toEqual({
+        installDir: "/app",
+        key: "alphaclaw",
+        spec: "git+https://github.com/garrytan/alphaclaw.git#main",
+        isGit: true,
+      });
+    });
+
+    it("resolves a legacy npm-pinned @chrysb/alphaclaw dependency", () => {
+      const fsImpl = makeFs({
+        "/app/package.json": {
+          dependencies: { "@chrysb/alphaclaw": "0.9.18" },
+        },
+      });
+      const result = resolveSelfDependency({
+        fsImpl,
+        startDir: "/app/node_modules/@chrysb/alphaclaw/lib/server",
+      });
+      expect(result.key).toBe("@chrysb/alphaclaw");
+      expect(result.spec).toBe("0.9.18");
+      expect(result.isGit).toBe(false);
+      expect(result.installDir).toBe("/app");
+    });
+
+    it("returns no dependency when none is declared", () => {
+      const fsImpl = makeFs({
+        "/app/package.json": { dependencies: { express: "^4.0.0" } },
+      });
+      const result = resolveSelfDependency({
+        fsImpl,
+        startDir: "/app/node_modules/alphaclaw/lib/server",
+      });
+      expect(result.key).toBeNull();
+      expect(result.spec).toBeNull();
+      expect(result.isGit).toBe(false);
+    });
+  });
+});

--- a/tests/server/usage-tracker-config.test.js
+++ b/tests/server/usage-tracker-config.test.js
@@ -5,6 +5,7 @@ const path = require("path");
 const {
   ensureUsageTrackerPluginConfig,
   ensureUsageTrackerPluginEntry,
+  pruneStaleUsageTrackerPaths,
   kUsageTrackerPluginPath,
 } = require("../../lib/server/usage-tracker-config");
 
@@ -96,5 +97,59 @@ describe("server/usage-tracker-config", () => {
     expect(next.plugins.entries["usage-tracker"].hooks).toEqual({
       allowConversationAccess: true,
     });
+  });
+
+  it("prunes a usage-tracker path left by a previous install location", () => {
+    const cfg = {
+      plugins: {
+        allow: [],
+        load: {
+          paths: [
+            "/app/node_modules/@chrysb/alphaclaw/lib/plugin/usage-tracker",
+            kUsageTrackerPluginPath,
+            "/app/node_modules/some-other-plugin",
+          ],
+        },
+        entries: {},
+      },
+    };
+
+    const changed = pruneStaleUsageTrackerPaths(cfg);
+
+    expect(changed).toBe(true);
+    expect(cfg.plugins.load.paths).toEqual([
+      kUsageTrackerPluginPath,
+      "/app/node_modules/some-other-plugin",
+    ]);
+  });
+
+  it("migrates a stale @chrysb usage-tracker path to the canonical path on boot", () => {
+    const openclawDir = createTempOpenclawDir();
+    const configPath = path.join(openclawDir, "openclaw.json");
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          plugins: {
+            allow: ["usage-tracker"],
+            load: {
+              paths: [
+                "/app/node_modules/@chrysb/alphaclaw/lib/plugin/usage-tracker",
+              ],
+            },
+            entries: { "usage-tracker": { enabled: true } },
+          },
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+
+    const changed = ensureUsageTrackerPluginConfig({ fsModule: fs, openclawDir });
+
+    expect(changed).toBe(true);
+    const next = JSON.parse(fs.readFileSync(configPath, "utf8"));
+    expect(next.plugins.load.paths).toEqual([kUsageTrackerPluginPath]);
   });
 });


### PR DESCRIPTION
Fixes the boot-blocking stale usage-tracker plugin path (config left by the old @chrysb npm install) and makes AlphaClaw git-deployment native: dual-key self-resolution, git-vs-npm-aware self-update (npm pins keep in-place update, git pins redeploy), package renamed to alphaclaw, fork URLs. 114 tests pass across affected suites.