### PR TITLE
v0.9.59 fix: agent-admin env-key tier bypass closed (whitespace + array coercion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to AlphaClaw are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow this repository's `package.json` release counter.
 
+## [0.9.59] - 2026-08-31
+
+Closes an agent-privilege-escalation hole in the environment editor.
+
+### Fixed
+- The Agent Administration tier gate can no longer be bypassed to repoint the
+  Claude Code launcher without an operator confirmation. A deployed agent
+  could previously smuggle a protected launcher key (e.g.
+  `CLAUDE_CODE_ROUTINE_URL`) past the "dangerous" tier by padding it with
+  whitespace/newlines or wrapping it as a JSON array — the tier check saw a
+  different key than the one actually written to disk. Key classification and
+  persistence now use one shared normalizer, and `PUT /api/env` rejects
+  malformed or non-string key names outright.
+
 ## [0.9.58] - 2026-08-31
 
 The hourly sync schedule can no longer be used to smuggle anything into the

--- a/lib/server/admin-manifest/domains/env.js
+++ b/lib/server/admin-manifest/domains/env.js
@@ -1,4 +1,4 @@
-const { readEnvFile } = require("../../env");
+const { readEnvFile, normalizeEnvVars } = require("../../env");
 const { isSensitiveKey } = require("../../helpers");
 const {
   isAgentEditableEnvKey,
@@ -24,10 +24,19 @@ const envUpdateTierResolver = (req) => {
   } catch {
     return "restart";
   }
+  // Canonicalize keys AND values through the SAME normalizer the write path
+  // uses (normalizeEnvVars → normalizeEnvKey), so tier resolution reasons
+  // about the exact keys/values that will be persisted. Without this a padded
+  // or linebroken protected key resolves to the base tier here yet writes
+  // canonical — the launcher-repoint bypass. Keep NON-string keys in the set
+  // (only drop null/undefined): normalizeEnvVars String()-coerces them just
+  // as the write path does, so an array-wrapped protected key
+  // ({"key":["CLAUDE_CODE_ROUTINE_URL"]}) is classified on its coerced form
+  // instead of slipping through as base tier.
   const submitted = new Map(
-    vars
-      .filter((v) => v && typeof v.key === "string")
-      .map((v) => [v.key, String(v.value ?? "")]),
+    normalizeEnvVars(vars.filter((v) => v && v.key != null)).map(
+      ({ key, value }) => [key, String(value ?? "")],
+    ),
   );
   const currentMap = new Map(
     current.map(({ key, value }) => [key, String(value ?? "")]),

--- a/lib/server/env.js
+++ b/lib/server/env.js
@@ -16,10 +16,17 @@ let pendingSelfWriteSignature = null;
 const stripLineBreaks = (value) =>
   String(value ?? "").replace(/[\r\n\u2028\u2029]/g, "");
 
+// The single key-normalization the write path applies before persisting.
+// Exported so the agent-admin tier resolver classifies the SAME canonical
+// key the file will hold \u2014 otherwise a padded/linebroken protected key
+// ("CLAUDE_CODE_ROUTINE_URL ") misses the raw-key Set check (base tier, no
+// operator confirm) yet persists canonical, repointing the launcher.
+const normalizeEnvKey = (key) => stripLineBreaks(key ?? "").trim();
+
 const normalizeEnvVars = (vars) => {
   const byKey = new Map();
   for (const entry of vars || []) {
-    const key = stripLineBreaks(entry?.key || "").trim();
+    const key = normalizeEnvKey(entry?.key || "");
     if (!key) continue;
     if (byKey.has(key)) byKey.delete(key);
     byKey.set(key, {
@@ -159,6 +166,7 @@ const startEnvWatcher = () => {
 
 module.exports = {
   normalizeEnvVars,
+  normalizeEnvKey,
   readEnvFile,
   readEnvFileStrict,
   writeEnvFile,

--- a/lib/server/routes/system.js
+++ b/lib/server/routes/system.js
@@ -430,6 +430,31 @@ const registerSystemRoutes = ({
     if (!Array.isArray(vars)) {
       return res.status(400).json({ ok: false, error: "Missing vars array" });
     }
+    // Reject malformed keys at the boundary (defense in depth for the
+    // agent-admin tier gate). Two classes are dangerous because the write
+    // path String()-coerces + strips line breaks + trims, so they can
+    // silently canonicalize into a DIFFERENT (protected) key that the tier
+    // resolver never saw:
+    //   1. a non-string key ({"key":["CLAUDE_CODE_ROUTINE_URL"]} coerces to
+    //      the protected string), and
+    //   2. a string key with interior whitespace/control chars or characters
+    //      outside the env-name charset.
+    // Grammar is [A-Za-z0-9_] (the exact output of the UI's client-side
+    // key normalizer, leading digits included, e.g. 2CAPTCHA_API_KEY);
+    // missing/empty keys are dropped by normalizeEnvVars, so they are no-ops
+    // here, not errors.
+    const malformedKey = vars.find((v) => {
+      if (!v || v.key === undefined || v.key === null || v.key === "") return false;
+      if (typeof v.key !== "string") return true;
+      const trimmed = v.key.trim();
+      return trimmed !== "" && !/^[A-Za-z0-9_]+$/.test(trimmed);
+    });
+    if (malformedKey) {
+      return res.status(400).json({
+        ok: false,
+        error: `Invalid environment variable name: ${JSON.stringify(String(malformedKey.key).slice(0, 64))}`,
+      });
+    }
     // Express 4 does not forward async rejections; an fs failure in
     // writeEnvFile (ENOSPC/EACCES) must become a 500, not a process crash.
     let releaseEnvSyncLock = null;

--- a/lib/server/utils/env-keys.js
+++ b/lib/server/utils/env-keys.js
@@ -1,4 +1,7 @@
 const { kSystemVars, kKnownVars } = require("../constants");
+// Acyclic: env.js requires only ./constants and ./utils/safe-file, neither of
+// which requires this module.
+const { normalizeEnvKey } = require("../env");
 
 // Env keys the /api/env editor and the agent-admin tier resolver must agree on.
 // Single source of truth so the manifest tierResolver (env.js) classifies keys
@@ -50,7 +53,11 @@ const kAgentProtectedEnvKeys = new Set([
   "CLAUDE_CODE_LOCAL_SPAWN_ON_INCIDENT",
 ]);
 
-const isAgentProtectedEnvKey = (key) => kAgentProtectedEnvKeys.has(key);
+// Normalize before the Set check: the write path persists the canonicalized
+// key, so a raw padded/linebroken key must resolve to the same protected
+// identity the resolver would escalate on (closes the tier-bypass).
+const isAgentProtectedEnvKey = (key) =>
+  kAgentProtectedEnvKeys.has(normalizeEnvKey(key));
 
 const isManagedChannelTokenKey = (key) =>
   kManagedChannelTokenPattern.test(String(key || "").trim().toUpperCase());

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.58",
+  "version": "0.9.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alphaclaw",
-      "version": "0.9.58",
+      "version": "0.9.59",
       "license": "MIT",
       "dependencies": {
         "compression": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.58",
+  "version": "0.9.59",
   "publishConfig": {
     "access": "public"
   },

--- a/tests/server/admin-manifest.test.js
+++ b/tests/server/admin-manifest.test.js
@@ -266,6 +266,64 @@ describe("admin-manifest env.update body-aware tierResolver (A1)", () => {
     expect(resolveEnvUpdate({ vars: [] })).toBe("dangerous");
   });
 
+  // PR #30 bypass regression: the resolver classified the RAW submitted key
+  // while the write path canonicalizes (stripLineBreaks + trim), so a padded
+  // or linebroken protected key slipped through at base tier yet persisted as
+  // the protected key — repointing the launcher with no operator confirm.
+  it("escalates to dangerous when a protected key is set with TRAILING WHITESPACE (bypass regression)", () => {
+    mockEnvFile([]);
+    expect(
+      resolveEnvUpdate({
+        vars: [{ key: "CLAUDE_CODE_ROUTINE_URL ", value: "trig_attacker" }],
+      }),
+    ).toBe("dangerous");
+  });
+
+  it("escalates to dangerous when a protected key is set with an embedded LINEBREAK (bypass regression)", () => {
+    mockEnvFile([]);
+    expect(
+      resolveEnvUpdate({
+        vars: [{ key: "CLAUDE_CODE_ROUTINE_TOKEN\n", value: "sk-ant-oat01-evil" }],
+      }),
+    ).toBe("dangerous");
+  });
+
+  it("does NOT escalate for a PADDED non-protected key (normalization is exact, not substring)", () => {
+    mockEnvFile([]);
+    expect(
+      resolveEnvUpdate({ vars: [{ key: "  FEATURE_FLAG  ", value: "1" }] }),
+    ).toBe("restart");
+  });
+
+  it("escalates to dangerous when a protected key is smuggled as a NON-STRING (array coercion)", () => {
+    // String(["CLAUDE_CODE_ROUTINE_URL"]) === "CLAUDE_CODE_ROUTINE_URL": the
+    // write path coerces, so the resolver must classify the coerced key, not
+    // filter non-strings out into the base tier.
+    mockEnvFile([]);
+    expect(
+      resolveEnvUpdate({
+        vars: [{ key: ["CLAUDE_CODE_ROUTINE_URL"], value: "http://evil/routine" }],
+      }),
+    ).toBe("dangerous");
+  });
+
+  it("escalates to dangerous for an array-coerced autonomous-spawn key", () => {
+    mockEnvFile([]);
+    expect(
+      resolveEnvUpdate({
+        vars: [{ key: ["CLAUDE_CODE_LOCAL_SPAWN_ON_INCIDENT"], value: "1" }],
+      }),
+    ).toBe("dangerous");
+  });
+
+  it("isAgentProtectedEnvKey normalizes its argument (unit)", () => {
+    const { isAgentProtectedEnvKey } = require("../../lib/server/utils/env-keys");
+    expect(isAgentProtectedEnvKey("CLAUDE_CODE_ROUTINE_URL ")).toBe(true);
+    expect(isAgentProtectedEnvKey("CLAUDE_CODE_ROUTINE_TOKEN\n")).toBe(true);
+    expect(isAgentProtectedEnvKey("CLAUDE_CODE_ROUTINE_URL")).toBe(true);
+    expect(isAgentProtectedEnvKey("FEATURE_FLAG")).toBe(false);
+  });
+
   it("stays restart when the launcher keys are unchanged (kept verbatim)", () => {
     mockEnvFile([
       { key: "CLAUDE_CODE_ROUTINE_URL", value: "trig_x" },

--- a/tests/server/routes-system.test.js
+++ b/tests/server/routes-system.test.js
@@ -247,6 +247,38 @@ describe("server/routes/system", () => {
     expect(deps.restartGateway).not.toHaveBeenCalled();
   });
 
+  it("rejects malformed env var names on PUT /api/env (tier-bypass boundary)", async () => {
+    const deps = createSystemDeps();
+    const app = createApp(deps);
+
+    // Interior whitespace / control chars would canonicalize into a
+    // different (possibly protected) key on write — reject at the boundary.
+    for (const key of [
+      "CLAUDE_CODE_ROUTINE_URL\nX",
+      "FOO BAR",
+      "has-dash",
+      "with.dot",
+    ]) {
+      const res = await request(app).put("/api/env").send({ vars: [{ key, value: "v" }] });
+      expect(res.status).toBe(400);
+      expect(res.body.ok).toBe(false);
+      expect(res.body.error).toContain("Invalid environment variable name");
+    }
+    // Non-string keys coerce on write (String(["X"])==="X"); reject them so a
+    // protected key can't be smuggled past the tier gate as an array.
+    for (const key of [["CLAUDE_CODE_ROUTINE_URL"], 42, { toString: () => "X" }]) {
+      const res = await request(app).put("/api/env").send({ vars: [{ key, value: "v" }] });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("Invalid environment variable name");
+    }
+    // Leading-digit keys are legitimate (the UI produces e.g. 2CAPTCHA_API_KEY)
+    // and trailing whitespace is benign — both accepted (not a 400).
+    for (const key of ["2CAPTCHA_API_KEY", "FEATURE_FLAG "]) {
+      const res = await request(app).put("/api/env").send({ vars: [{ key, value: "1" }] });
+      expect(res.status).not.toBe(400);
+    }
+  });
+
   it("rejects gog keyring password edits on PUT /api/env", async () => {
     const deps = createSystemDeps();
     const app = createApp(deps);


### PR DESCRIPTION
## Summary

Closes the agent-admin dangerous-tier bypass on `PUT /api/env` (workstream A3 of the remediation plan) — the launcher-repoint hole PR #30 claimed to close but left open.

**The bypass:** the env.update tier resolver classified the RAW submitted key, while the write path canonicalizes (`stripLineBreaks` + `trim`, and `String()`-coercion). So a protected launcher key reached the base `restart` tier (no operator confirm) yet persisted as the protected key — letting a compromised agent repoint the operator's one-click Claude Code launcher (or arm `CLAUDE_CODE_LOCAL_*` autonomous spawns) at an agent-chosen routine + token.

**Two vectors, both closed (found across 5 specialist lenses + Claude & Codex adversarial):**
- **Whitespace/linebreak padding** (`"CLAUDE_CODE_ROUTINE_URL "`, embedded `\n`): the resolver now builds its `submitted` map through the shared `normalizeEnvVars`, and `isAgentProtectedEnvKey` normalizes its argument via a new `normalizeEnvKey` export (single source of truth; the `env-keys → env` require chain was verified acyclic statically and at runtime, and a throwing resolver fails closed to `dangerous`).
- **Non-string coercion** (`{"key":["CLAUDE_CODE_ROUTINE_URL"]}` → `String()` → the protected key): flagged as CRITICAL/P1 by BOTH adversarial passes. The resolver no longer filters non-string keys out (it classifies their coerced form), and `PUT /api/env` rejects non-string and out-of-grammar keys at the boundary.

**Grammar choice:** the boundary check is `^[A-Za-z0-9_]+$` — exactly the output charset of the UI's own client-side key normalizer, so legitimate leading-digit keys (`2CAPTCHA_API_KEY`) still save (an api-contract finding: an earlier `^[A-Za-z_]…` draft would have 400'd them). Empty/whitespace-only keys stay no-ops (dropped by `normalizeEnvVars`, matching the resolver), so they aren't spurious 400s.

## Test Coverage

Regression tests in `tests/server/admin-manifest.test.js` (resolver) and `tests/server/routes-system.test.js` (route boundary): padded-key → dangerous, linebreak-key → dangerous, **array-coerced protected key → dangerous**, array-coerced autonomous-spawn key → dangerous, padded non-protected key → restart, `isAgentProtectedEnvKey` normalization unit, route 400s for interior-whitespace/dash/dot/non-string keys, and route ACCEPTS leading-digit + trailing-whitespace keys. 6 fail without the fix (2 for the string vector, 2 for the array vector, boundary + normalization). Full suite green.

## Pre-Landing Review

Specialists (security, maintainability, api-contract): security returned NO FINDINGS after a 20-case unicode/case-fold/value-side probe confirming zero resolver-vs-persist disagreements and the acyclic require. api-contract/maintainability surfaced the leading-digit regression (fixed by the `[A-Za-z0-9_]` grammar) and a three-definitions-of-env-name-grammar observation (deferred — onboarding's stricter uppercase-only rule is a separate surface; noted for a future consolidation). Claude adversarial + Codex both independently found the non-string coercion P1 — **fixed in this PR** and pinned by tests. No surviving criticals.

## Design Review

No frontend files changed — design review skipped.

## Eval Results / Scope Drift

No prompt files — evals skipped. Scope Check: CLEAN (A3 only: resolver, env normalizer, env-keys, route boundary, manifest-adjacent tests).

## Plan Completion

Workstream A3 (PR 3 of 8): all planned layers DONE (Layer 1 resolver normalization, Layer 2 predicate normalization, Layer 3 route-boundary rejection) plus the coercion vector both adversarial passes surfaced.

## TODOS

No completions; no new deferrals (the env-name-grammar consolidation is noted here rather than filed — it predates this PR and spans onboarding + frontend).

## Test plan

- [x] Full Vitest suite green on merged main (post v0.9.58)
- [x] 6 tests fail without the fix (stash-verified, both vectors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/342ca9ae-db30-493d-8812-203a6fbdd46d)
