### PR TITLE
v0.9.61 docs: Merge unification safety policy in CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@ Runtime model:
 ### Change Patterns
 
 - Keep edits targeted and production-safe; favor small, reviewable changes.
+- Before starting and before merging, follow the **Merge unification safety** rules in `CLAUDE.md` — `main` moves fast and parallel branches on one subsystem have destroyed each other's freshly-merged work here.
 - Preserve existing behavior unless the task explicitly requires behavior changes.
 - Follow existing UI conventions and shared components for consistency.
 - Reuse existing server route and state patterns before introducing new abstractions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to AlphaClaw are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow this repository's `package.json` release counter.
 
+## [0.9.61] - 2026-08-31
+
+### Changed
+- Added a **Merge unification safety** policy to the contributor guide
+  (`CLAUDE.md`): check for overlapping in-flight branches before starting,
+  never run two branches against one subsystem, merge `main` and reconcile
+  file-by-file before landing, claim version numbers at merge time, and
+  justify any rewrite of code merged in the last 7 days. Codifies the
+  reconciliation discipline that keeps fast-moving parallel work from
+  clobbering freshly-merged fixes. Docs/process only — no runtime change.
+
 ## [0.9.59] - 2026-08-31
 
 Closes an agent-privilege-escalation hole in the environment editor.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,3 +24,34 @@ Key routing rules:
 ## Testing
 
 Run `npm test` (Vitest). UI bundle: `npm run build:ui` after any lib/public/js change.
+
+## Merge unification safety
+
+Parallel agent branches on the same subsystem have repeatedly destroyed each
+other's freshly-merged work in this repo: #13 rewrote day-old #8, #14 dropped
+#6's team-session model, and #29/#32 fixed the same bug twice, then #32 grafted
+its migration engine over main's already-landed #29 fix. `main` also moves fast
+enough that a branch's version number is stale by the time it's ready. Follow
+these rules on every branch:
+
+- **Before starting, check in-flight PRs for overlap with your target files:**
+  `gh pr list --state open --json number,headRefName,files --jq '.[] | "#\(.number) \(.headRefName) \(.files[].path)"' | grep <path-prefix>`
+  If an open PR touches your subsystem, sequence behind it or take it over — do
+  not fork a rival branch against the same file cluster.
+- **Never run two concurrent branches against the same subsystem.** One
+  subsystem, one in-flight branch at a time.
+- **On any conflict or semantic overlap with freshly-merged `main`:** stop,
+  `git merge origin/main` FIRST, then list every file where both sides changed
+  behavior and reconcile each one explicitly. `main`'s merged semantics win by
+  default — never silently keep "mine". Re-run `npm test` (and `npm run
+  test:container` when the change touches the gateway/upgrade/boot spine; record
+  "container tier not runnable here" if Docker is unavailable), then describe
+  the reconciliation file-by-file in the PR body.
+- **Version numbers are claimed at merge time, not branch time.** After merging
+  `main`, renumber `package.json`/`package-lock.json`/`CHANGELOG.md` to the next
+  free version and stack your CHANGELOG entry above the ones that landed while
+  you were out. `VERSION` is not a tracked file — `package.json` is the source
+  of truth.
+- **Deleting or rewriting code merged within the last 7 days requires a
+  "Supersedes recent work" section in the PR body:** name the prior PR, each
+  file removed or rewritten, and why replacement beats extension.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.59",
+  "version": "0.9.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alphaclaw",
-      "version": "0.9.59",
+      "version": "0.9.61",
       "license": "MIT",
       "dependencies": {
         "compression": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.59",
+  "version": "0.9.61",
   "publishConfig": {
     "access": "public"
   },

--- a/tests/docs/merge-safety-policy.test.js
+++ b/tests/docs/merge-safety-policy.test.js
@@ -1,0 +1,29 @@
+const { readFileSync } = require("node:fs");
+const path = require("node:path");
+
+// Policy guard: CLAUDE.md's merge-unification safety rules must exist and keep
+// their enforceable teeth. Born from the v0.9.34–v0.9.60 wave, where #13
+// rewrote day-old #8, #14 dropped #6, and #32 grafted its migration engine
+// over main's #29 fix — each by declaring itself "the base" without
+// reconciling. A phrase-presence guard, not behavior enforcement.
+const kClaudeMd = readFileSync(
+  path.join(__dirname, "..", "..", "CLAUDE.md"),
+  "utf8",
+);
+
+describe("CLAUDE.md merge unification safety policy", () => {
+  it("has the policy section", () => {
+    expect(kClaudeMd).toContain("## Merge unification safety");
+  });
+
+  it("keeps the enforceable rules intact", () => {
+    const section = kClaudeMd.split("## Merge unification safety")[1] ?? "";
+    expect(section).toContain("gh pr list"); // pre-work overlap check
+    expect(section).toContain("two concurrent branches"); // sequence, don't parallelize
+    expect(section).toContain("git merge origin/main"); // merge main first
+    expect(section).toContain("file-by-file"); // reconciliation disclosure
+    expect(section).toContain("test:container"); // full-suite + container tier on reconcile
+    expect(section).toContain("Supersedes recent work"); // recent-rewrite justification
+    expect(section).toContain("7 days"); // the recency window
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **Merge unification safety** policy to `CLAUDE.md` (workstream C of the remediation plan) — the "figure out how to be safer about merge-unification work and note it in CLAUDE.md" ask.

The last 20-PR wave repeatedly had parallel branches destroy each other's freshly-merged work: #13 rewrote day-old #8, #14 dropped #6's team-session model, and #29/#32 fixed the same bug twice before #32 grafted its migration engine over main's already-landed #29 fix. This policy codifies the reconciliation discipline that prevents it.

Five rules:
1. Before starting, check in-flight PRs for file overlap (`gh pr list … --json files`) and sequence behind / take over any branch on your subsystem.
2. Never run two concurrent branches against one subsystem.
3. On any conflict or semantic overlap with freshly-merged `main`: merge main first, reconcile every both-sides-changed file explicitly (main's semantics win by default), re-run `npm test` (+ container tier for the gateway/upgrade/boot spine), and describe the reconciliation file-by-file in the PR body.
4. Version numbers are claimed at merge time, not branch time (renumber + stack the CHANGELOG entry after merging main; `package.json` is the source of truth, not `VERSION`).
5. Rewriting code merged in the last 7 days needs a "Supersedes recent work" PR-body section.

This is not theoretical — it's the exact process the four security-fix PRs in this same remediation series each had to follow (every one needed a merge-main + renumber reconciliation because main advanced underneath it).

## Test Coverage

`tests/docs/merge-safety-policy.test.js` guards the section's presence and its enforceable phrases (so a future edit can't quietly gut it). Acknowledged as a presence guard, not behavior enforcement. `AGENTS.md`'s Change Patterns cross-references the policy.

## Pre-Landing Review / Design / Eval / Scope

Docs + one docs-test only — no runtime code changes. No frontend (design skipped), no prompt files (evals skipped). Scope Check: CLEAN. Full Vitest suite green.

## Test plan

- [x] Full Vitest suite green on merged main
- [x] Docs guard passes; fails if the policy phrases are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/342ca9ae-db30-493d-8812-203a6fbdd46d)
