### PR TITLE
v0.9.62 ci: merge gate — version guard, soak window, release tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,26 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
+
+      # Version guard: a PR's package.json version must strictly advance the
+      # base branch's, so concurrent PRs can't both claim the same number and
+      # slip through (the renumber races the v0.9.3x–v0.9.6x wave hit). Every
+      # PR bumps, including reverts. See CLAUDE.md "Merge unification safety".
+      - name: Version guard
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git show "origin/${BASE_REF}:package.json" > /tmp/base-package.json
+          node scripts/ci/assert-version-advances.mjs /tmp/base-package.json ./package.json
 
       - run: npm ci
 

--- a/.github/workflows/container-e2e.yml
+++ b/.github/workflows/container-e2e.yml
@@ -50,7 +50,12 @@ jobs:
           changed=$(git diff --name-only "origin/${BASE_REF}...HEAD")
           echo "changed files:"
           echo "$changed"
-          pattern='^(lib/server/openclaw-|lib/server/gateway|bin/alphaclaw\.js|Dockerfile|tests/container/|lib/boot-placeholder)'
+          # The heavy job boots the FULL server on the container journey:
+          # watchdog, boot-time doctor/config reconcile, startup, and every
+          # routes/* module load. The original filter covered only the
+          # upgrade/gateway surface, so PRs changing watchdog/doctor/routes/
+          # server-core (which the boot journey exercises) skipped it.
+          pattern='^(lib/server/openclaw-|lib/server/gateway|lib/server/watchdog|lib/server/doctor|lib/server/routes/|lib/server/startup\.js|lib/server/boot-phase\.js|lib/server\.js|lib/server/gateway-env-policy\.js|bin/alphaclaw\.js|Dockerfile|tests/container/|lib/boot-placeholder)'
           if echo "$changed" | grep -qE "$pattern"; then
             echo "run_heavy=true" >> "$GITHUB_OUTPUT"
             echo "upgrade/gateway/container surface touched → heavy job runs"

--- a/.github/workflows/soak.yml
+++ b/.github/workflows/soak.yml
@@ -1,0 +1,88 @@
+# Soak gate: a required check that stays RED until a PR's current head commit
+# has been open long enough for a human to actually read it, then flips green.
+# Born from the audit finding that 7/20 PRs merged in <15 min (one 23-fix
+# security wave in 2 minutes). RED-until-ripe is NORMAL here, not broken CI —
+# add the `expedite` label to override (audit-logged as a label event).
+#
+# Time source is non-forgeable: the created_at of the FIRST Actions run for the
+# current head SHA (GitHub-stamped at push), not a git commit date the author
+# controls. Known interaction: a rebase/new-push starts a fresh head SHA and so
+# resets the clock — acceptable given the `expedite` override and the ripen
+# job; a patch-id-based inheritance refinement is noted in the remediation plan.
+name: Soak
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  soak:
+    runs-on: ubuntu-latest
+    env:
+      SOAK_HOURS: "2"
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Enforce soak window (unless expedited)
+        run: |
+          set -euo pipefail
+          labels='${{ toJSON(github.event.pull_request.labels.*.name) }}'
+          if echo "$labels" | grep -q '"expedite"'; then
+            echo "::notice::expedite label present — soak window waived."
+            exit 0
+          fi
+          head_sha='${{ github.event.pull_request.head.sha }}'
+          repo='${{ github.repository }}'
+          # Earliest Actions run for this head SHA = GitHub-stamped push time.
+          first_created=$(gh api "repos/${repo}/actions/runs?head_sha=${head_sha}&per_page=100" \
+            --jq '[.workflow_runs[].created_at] | sort | .[0] // empty')
+          if [ -z "$first_created" ]; then
+            echo "::error::No Actions run found yet for ${head_sha}; the check will re-evaluate on the next run (see the ripen job)."
+            exit 1
+          fi
+          first_epoch=$(date -u -d "$first_created" +%s)
+          now_epoch=$(date -u +%s)
+          age_min=$(( (now_epoch - first_epoch) / 60 ))
+          need_min=$(( SOAK_HOURS * 60 ))
+          echo "Head ${head_sha} first seen ${first_created} (${age_min} min ago); soak needs ${need_min} min."
+          if [ "$age_min" -lt "$need_min" ]; then
+            echo "::error::Soak window not met: ${age_min}/${need_min} min. RED-until-ripe is expected — the ripen job re-checks every 30 min, or add the 'expedite' label to override."
+            exit 1
+          fi
+          echo "::notice::Soak window met (${age_min} min)."
+
+  # Scheduled re-runner: the soak check can't re-evaluate itself once time
+  # passes, so re-run the latest failed soak run on every open PR. Within ~30
+  # min of a PR ripening, its soak check flips green with no human action.
+  ripen:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Re-run failed soak checks on open PRs
+        run: |
+          set -euo pipefail
+          repo='${{ github.repository }}'
+          for pr in $(gh api "repos/${repo}/pulls?state=open&per_page=100" --jq '.[].number'); do
+            head=$(gh api "repos/${repo}/pulls/${pr}" --jq '.head.sha')
+            run=$(gh api "repos/${repo}/actions/workflows/soak.yml/runs?head_sha=${head}&per_page=1" \
+              --jq '.workflow_runs[0] | select(.conclusion=="failure") | .id' || true)
+            if [ -n "${run:-}" ]; then
+              echo "Re-running soak run ${run} for PR #${pr}"
+              gh api --method POST "repos/${repo}/actions/runs/${run}/rerun-failed-jobs" || true
+            fi
+          done
+
+# Cron delivery has NO guaranteed bound (typically minutes to tens of minutes);
+# `workflow_dispatch` is the manual fallback. Note the `schedule`/`dispatch`
+# triggers are additive to the pull_request trigger above.

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,44 @@
+# Tag every merged version on main. The audit found zero git tags across 20
+# releases (releases existed only as package.json strings) and version numbers
+# racing across concurrent PRs. On each push to main this creates v<version>
+# at the merge commit; if the tag already exists at a DIFFERENT sha it fails
+# loudly — that is the renumber-race tripwire (two merges claimed one version).
+#
+# Note: tags created with GITHUB_TOKEN do not trigger further tag-triggered
+# workflows (none exist today). Tags mark merged repo versions; npm publishes
+# remain a separate, manual step (see AGENTS.md release flow).
+name: Tag release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Tag v<package.json version> if new
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+          tag="v${version}"
+          sha='${{ github.sha }}'
+          existing=$(git rev-parse -q --verify "refs/tags/${tag}" || true)
+          if [ -z "$existing" ]; then
+            git tag "$tag" "$sha"
+            git push origin "$tag"
+            echo "::notice::Tagged ${tag} at ${sha}."
+          elif [ "$existing" = "$sha" ]; then
+            echo "::notice::${tag} already exists at ${sha} — nothing to do."
+          else
+            echo "::error::${tag} already exists at ${existing}, but this push is ${sha}. Two merges claimed version ${version} — renumber one (see CLAUDE.md 'Merge unification safety')."
+            exit 1
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,19 +87,49 @@ The Agent Administration feature (default OFF) lets the deployed OpenClaw agent 
 
 ## Operations
 
+### Merge Gate (branch protection on `main`)
+
+A GitHub ruleset protects `main`: PRs required (no direct pushes), squash-only,
+required conversation resolution, strict up-to-date, and required status checks
+`test (22)`, `gate` (the always-running container-e2e aggregator), and `soak`.
+There are 0 required approvals — this is a solo repo where any higher count
+deadlocks; the gate is CI + a soak window, not human sign-off. Details:
+
+- **Version guard** (`scripts/ci/assert-version-advances.mjs`, run in `ci.yml`
+  on PRs): a PR's `package.json` version must strictly advance `main`'s. Every
+  PR bumps, including reverts. This is why versions are claimed at merge time,
+  not branch time (see CLAUDE.md "Merge unification safety"). `VERSION` is not a
+  tracked file — `package.json` is the source of truth.
+- **Soak** (`soak.yml`): a required check that stays RED until the current head
+  commit has been open ≥ 2h (measured from the first Actions run for that head
+  SHA — GitHub-stamped, not author-forgeable). **RED-until-ripe is normal, not
+  broken CI.** Add the `expedite` label to override (audit-logged). A `ripen`
+  cron re-runs failed soak checks every ~30 min so a ripened PR flips green with
+  no manual action; cron delivery has no guaranteed bound, and
+  `workflow_dispatch` is the manual fallback.
+- **Tags** (`tag-release.yml`): each push to `main` tags `v<version>`; a
+  same-version/different-sha collision fails loudly (the renumber-race tripwire).
+- **Break-glass:** disable the ruleset (`gh api --method PUT
+  repos/<owner>/<repo>/rulesets/<id> -f enforcement=disabled`) — every use is in
+  the audit log. Re-enable after.
+
+Because versions bump inside PRs, the release flow below no longer runs
+`npm version` — publish the already-bumped version and let `tag-release.yml`
+create the tag.
+
 ### Release Flow (Beta -> Production)
 
 Use this release flow when promoting tested beta builds to production:
 
 1. Ensure `main` is clean and synced, and tests pass.
-2. Publish beta iterations as needed:
-   - `npm version prerelease --preid=beta`
-   - `git push && git push --tags`
+2. Publish beta iterations as needed (the version was already bumped in-PR; do
+   NOT run `npm version` — it would create an untagged second bump and a git
+   tag that races `tag-release.yml`):
    - `npm publish --tag beta`
 3. Immediately after each beta publish, update `~/Projects/openclaw-railway-template` on the `beta` branch to pin the exact beta version in `package.json` (for example `0.3.2-beta.4`), then commit and push that template change. Do not leave the beta template on `latest`, or Docker layer cache can reuse an older install.
-4. When ready for production, publish a stable release version (for example `0.3.2`):
-   - `npm version 0.3.2`
-   - `git push && git push --tags`
+4. When ready for production, publish the stable release version already on
+   `main` (do NOT run `npm version`; `tag-release.yml` created the `v<version>`
+   tag on merge):
    - `npm publish` (publishes to `latest`)
    - Pin all deployment templates on `main` to that release: set `@chrysb/alphaclaw` in `~/Projects/openclaw-railway-template`, `~/Projects/openclaw-render-template`, and `~/Projects/openclaw-apex-template` to the released version. The Render checkout must track `render-examples/openclaw-render-template`; verify `gh api repos/render-examples/openclaw-render-template --jq '.permissions.push'` returns `true` before publishing, and stop if write access is missing. Templates rely on AlphaClaw’s declared `openclaw` dependency — do not add `package.json` `overrides` for `openclaw` unless you have a one-off debug reason. Run `npm install` in each repo, confirm `npm ls openclaw` matches AlphaClaw’s `package.json` pin, commit `package.json` and `package-lock.json`, and push. Skipping a template leaves it stale relative to the others.
 5. Return templates to production channel:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to AlphaClaw are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow this repository's `package.json` release counter.
 
+## [0.9.62] - 2026-08-31
+
+### Added
+- **Merge gate on `main`** (the CI half; the branch-protection ruleset is
+  configured separately): a **version guard** fails any PR whose
+  `package.json` version does not strictly advance `main` (kills the
+  concurrent-version-claim races that forced unreviewed renumbering), a
+  **soak** check that keeps a PR red until its current commit has been open
+  ≥2h — measured from a non-forgeable GitHub timestamp, overridable with an
+  `expedite` label and auto-re-checked by a 30-min `ripen` job — and a
+  **tag-release** workflow that tags `v<version>` on every merge and trips
+  loudly on a duplicate-version collision. The container-E2E path filter was
+  widened to cover the watchdog/doctor/routes/server-core surfaces the boot
+  journey exercises. Contributor release flow updated: versions bump inside
+  PRs, so `npm version` is no longer part of publishing.
+
 ## [0.9.59] - 2026-08-31
 
 Closes an agent-privilege-escalation hole in the environment editor.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.59",
+  "version": "0.9.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alphaclaw",
-      "version": "0.9.59",
+      "version": "0.9.62",
       "license": "MIT",
       "dependencies": {
         "compression": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.59",
+  "version": "0.9.62",
   "publishConfig": {
     "access": "public"
   },

--- a/scripts/ci/assert-version-advances.mjs
+++ b/scripts/ci/assert-version-advances.mjs
@@ -1,0 +1,78 @@
+// CI version guard: fail a PR whose package.json version does not strictly
+// advance the base branch's version. This surfaces the concurrent-version-claim
+// races the v0.9.34–v0.9.60 wave hit (multiple open PRs claiming the same
+// number, forcing unreviewed renumber+merge reconciliation) at PR time instead
+// of at merge time. Deliberately serializes version claims — that cost IS the
+// fix. Every PR, including reverts, must bump.
+//
+// Usage: node scripts/ci/assert-version-advances.mjs <base-package.json> <head-package.json>
+import { readFileSync } from "node:fs";
+
+// Parse "MAJOR.MINOR.PATCH[.MICRO][-prerelease.N]" into comparable parts.
+export const parseCore = (version) => {
+  const raw = String(version || "").trim();
+  const [core, ...preParts] = raw.split("-");
+  const pre = preParts.join("-");
+  const nums = core.split(".").map((n) => Number(n));
+  if (nums.length < 3 || nums.some((n) => !Number.isInteger(n) || n < 0)) {
+    throw new Error(`unparseable version: ${JSON.stringify(raw)}`);
+  }
+  // Pad to 4 components (MICRO defaults to 0) so 0.9.60 and 0.9.60.0 compare equal.
+  while (nums.length < 4) nums.push(0);
+  return { nums: nums.slice(0, 4), pre };
+};
+
+// Returns true iff `next` is a strictly greater release than `prev`.
+// Rules: numeric cores compare left-to-right. A prerelease (has `-tag`) is
+// LOWER than the same core without one (0.9.61-beta.1 < 0.9.61), matching npm
+// and the repo's --preid=beta flow; two prereleases of the same core compare
+// lexically (beta.2 > beta.10 would be wrong, but the repo only uses single
+// increasing counters and this guard just needs monotonicity, not full semver).
+export const versionAdvances = (nextVersion, prevVersion) => {
+  const next = parseCore(nextVersion);
+  const prev = parseCore(prevVersion);
+  for (let i = 0; i < 4; i += 1) {
+    if (next.nums[i] > prev.nums[i]) return true;
+    if (next.nums[i] < prev.nums[i]) return false;
+  }
+  // Cores equal — decide on the prerelease tail.
+  if (next.pre === prev.pre) return false; // identical version, no advance
+  if (!next.pre && prev.pre) return true; // release > its own prerelease
+  if (next.pre && !prev.pre) return false; // prerelease < the release
+  return next.pre > prev.pre; // both prerelease: lexical (single counters only)
+};
+
+const readVersion = (path) => {
+  const pkg = JSON.parse(readFileSync(path, "utf8"));
+  if (!pkg.version) throw new Error(`no version field in ${path}`);
+  return pkg.version;
+};
+
+// CLI entry (skipped when imported by tests).
+const isMain =
+  process.argv[1] && process.argv[1].endsWith("assert-version-advances.mjs");
+if (isMain) {
+  const [basePath, headPath] = process.argv.slice(2);
+  if (!basePath || !headPath) {
+    console.error(
+      "usage: assert-version-advances.mjs <base-package.json> <head-package.json>",
+    );
+    process.exit(2);
+  }
+  try {
+    const base = readVersion(basePath);
+    const head = readVersion(headPath);
+    if (!versionAdvances(head, base)) {
+      console.error(
+        `Version guard FAILED: package.json version ${head} does not advance base ${base}. ` +
+          `Bump the version (every PR must, including reverts) — main moves fast, so claim the ` +
+          `next free number at merge time. See CLAUDE.md "Merge unification safety".`,
+      );
+      process.exit(1);
+    }
+    console.log(`Version guard OK: ${head} advances ${base}.`);
+  } catch (err) {
+    console.error(`Version guard ERROR: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/tests/ci/version-guard.test.js
+++ b/tests/ci/version-guard.test.js
@@ -1,0 +1,42 @@
+const path = require("node:path");
+
+// The version guard is an ESM module (.mjs); import it dynamically.
+const loadGuard = () =>
+  import(
+    path.join(__dirname, "..", "..", "scripts", "ci", "assert-version-advances.mjs")
+  );
+
+describe("ci/assert-version-advances", () => {
+  it("parseCore pads MICRO and rejects garbage", async () => {
+    const { parseCore } = await loadGuard();
+    expect(parseCore("0.9.60").nums).toEqual([0, 9, 60, 0]);
+    expect(parseCore("0.9.60.2").nums).toEqual([0, 9, 60, 2]);
+    expect(parseCore("1.2.3-beta.4").pre).toBe("beta.4");
+    expect(() => parseCore("not.a.version")).toThrow();
+    expect(() => parseCore("1.2")).toThrow();
+  });
+
+  it("advances on patch/minor/major/micro bumps", async () => {
+    const { versionAdvances } = await loadGuard();
+    expect(versionAdvances("0.9.61", "0.9.60")).toBe(true);
+    expect(versionAdvances("0.10.0", "0.9.60")).toBe(true);
+    expect(versionAdvances("1.0.0", "0.9.60")).toBe(true);
+    expect(versionAdvances("0.9.60.1", "0.9.60")).toBe(true);
+  });
+
+  it("rejects equal or regressing versions", async () => {
+    const { versionAdvances } = await loadGuard();
+    expect(versionAdvances("0.9.60", "0.9.60")).toBe(false);
+    expect(versionAdvances("0.9.59", "0.9.60")).toBe(false);
+    expect(versionAdvances("0.9.60.0", "0.9.60")).toBe(false); // equal (micro pad)
+    expect(versionAdvances("0.8.99", "0.9.0")).toBe(false);
+  });
+
+  it("orders prereleases below their release, above the prior release", async () => {
+    const { versionAdvances } = await loadGuard();
+    expect(versionAdvances("0.9.61-beta.1", "0.9.60")).toBe(true); // beta of next > prior
+    expect(versionAdvances("0.9.61", "0.9.61-beta.1")).toBe(true); // release > its beta
+    expect(versionAdvances("0.9.61-beta.1", "0.9.61")).toBe(false); // beta < release
+    expect(versionAdvances("0.9.61-beta.2", "0.9.61-beta.1")).toBe(true); // beta counter up
+  });
+});

--- a/tests/ci/workflow-contract.test.js
+++ b/tests/ci/workflow-contract.test.js
@@ -1,0 +1,59 @@
+const { readFileSync } = require("node:fs");
+const path = require("node:path");
+
+// Structural guards over the merge-gate CI (which cannot be executed in the
+// hermetic suite). They pin the contract the GitHub ruleset binds to — a
+// rename that breaks a required check should fail HERE, in the PR that makes
+// it, not silently at merge time.
+const wf = (name) =>
+  readFileSync(
+    path.join(__dirname, "..", "..", ".github", "workflows", name),
+    "utf8",
+  );
+
+describe("ci/merge-gate workflow contract", () => {
+  it("ci.yml keeps the required check name 'test (22)' and runs the version guard on PRs", () => {
+    const ci = wf("ci.yml");
+    // The ruleset requires the context "test (22)" (job `test`, node matrix [22]).
+    expect(ci).toMatch(/job.*\n\s*test:|^\s{2}test:/m);
+    expect(ci).toMatch(/node-version:\s*\[22\]/);
+    expect(ci).toContain("assert-version-advances.mjs");
+    expect(ci).toMatch(/if:\s*github\.event_name == 'pull_request'/);
+  });
+
+  it("container-e2e keeps the always-running 'gate' aggregator and covers the boot-journey paths", () => {
+    const c = wf("container-e2e.yml");
+    // `gate` is the required context (container-e2e itself is conditionally skipped).
+    expect(c).toMatch(/^\s{2}gate:/m);
+    expect(c).toMatch(/if:\s*always\(\)/);
+    // The widened filter must cover the surfaces the boot journey exercises.
+    for (const p of [
+      "lib/server/watchdog",
+      "lib/server/doctor",
+      "lib/server/routes/",
+      "lib/server\\.js",
+    ]) {
+      expect(c).toContain(p);
+    }
+  });
+
+  it("soak.yml gates on a soak window with an expedite override and a ripen re-runner", () => {
+    const s = wf("soak.yml");
+    expect(s).toMatch(/^\s{2}soak:/m);
+    expect(s).toContain("SOAK_HOURS");
+    expect(s).toContain('"expedite"');
+    expect(s).toMatch(/^\s{2}ripen:/m);
+    expect(s).toContain("rerun-failed-jobs");
+    // Non-forgeable time source: first Actions run for the head SHA.
+    expect(s).toContain("actions/runs?head_sha=");
+  });
+
+  it("tag-release.yml tags on main push and trips on a duplicate-version collision", () => {
+    const t = wf("tag-release.yml");
+    expect(t).toMatch(/branches:\s*\[main\]/);
+    expect(t).toContain("contents: write");
+    expect(t).toContain('git tag "$tag"');
+    // The renumber-race tripwire: same tag, different sha → fail.
+    expect(t).toMatch(/already exists at .* but this push is/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the CI half of the merge gate the PR-quality audit called for (workstream B). The audit found: all 20 recent PRs self-merged with no gate, 7 in <15 min (a 23-fix security wave in 2 minutes), no git tags across 20 releases, and version numbers racing across concurrent PRs. The main-branch **ruleset** (PR-required, squash-only, required checks `test (22)` + `gate` + `soak`, 0 approvals for a solo repo, strict up-to-date) is applied separately as an admin action; this PR is the workflow/script half it binds to.

**Two-phase activation (per the plan):** a minimal ruleset (PR-required + `test (22)` + `gate`) is already live so the security-fix PRs in this series merged under a real gate; this PR adds the `soak`/version-guard/tagging layer, after which the ruleset is updated to require `soak`.

Pieces:
- **Version guard** (`scripts/ci/assert-version-advances.mjs`, wired into `ci.yml` on PRs): a PR's `package.json` version must strictly advance `main`'s — every PR bumps, including reverts. Surfaces the concurrent-version-claim races at PR time instead of forcing unreviewed renumber+merge reconciliation. Fully unit-tested (parse/advance/equal/regress/prerelease ordering).
- **Soak** (`soak.yml`): a required check that stays RED until the current head commit has been open ≥2h, measured from the **first Actions run's `created_at` for the head SHA** — GitHub-stamped, not an author-forgeable git date. `expedite` label overrides (audit-logged); a `ripen` cron re-runs failed soak checks every ~30 min so a ripened PR flips green with no manual action. **RED-until-ripe is normal, documented in the failure message and AGENTS.md.**
- **Tag release** (`tag-release.yml`): tags `v<version>` on each push to `main`; a same-version/different-sha collision fails loudly — the renumber-race tripwire.
- **Container-e2e filter widened** to `watchdog`/`doctor`/`routes/`/`server.js`/`startup.js`/`boot-phase.js`/`gateway-env-policy.js` — the boot-journey surfaces the original filter missed (it SKIPPED on doctor/watchdog PRs).
- **AGENTS.md**: a Merge Gate section documenting the ruleset, soak semantics ("red until ripe is normal"), the break-glass, and — since versions now bump in-PR — a release flow amended to drop `npm version`.

## Known limitation (honest)

A rebase/new push starts a fresh head SHA and resets the soak clock. Acceptable given the `expedite` override and the `ripen` job; a `git patch-id`-based inheritance refinement (so content-identical rebases don't reset soak) is designed in the remediation plan but deliberately not implemented in untested YAML/bash — a simple, correct, documented version beats a clever one I can't execute here.

## Test Coverage

`tests/ci/version-guard.test.js` (4 tests, full logic of the guard script) + `tests/ci/workflow-contract.test.js` (4 tests pinning the structural contract the ruleset binds to: `test (22)` name + PR version-guard step; the always-running `gate` aggregator + widened filter paths; soak window + expedite + ripen + non-forgeable time source; tag-on-push + collision tripwire). These pin the contract so a rename that breaks a required check fails in the PR that makes it. The workflows themselves can't run in the hermetic suite; both YAML files validated with js-yaml. Full suite green.

## Admin action after merge

Update the main ruleset to add `soak` to required checks: `gh api --method PUT repos/<owner>/<repo>/rulesets/<id> …`. Requires repo-admin (the sandbox token got 403 on ruleset writes; run from an admin session).

## Pre-Landing / Design / Eval / Scope

CI/infra + tests only. No frontend (design skipped), no prompt files (evals skipped). Scope Check: CLEAN. Full Vitest suite green.

## Test plan

- [x] Full Vitest suite green
- [x] Version-guard script unit-tested (advance/equal/regress/prerelease)
- [x] Both new workflow YAMLs parse (js-yaml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/342ca9ae-db30-493d-8812-203a6fbdd46d)
