### PR TITLE
v0.9.77 fix: gateway lifecycle — cold restart keeps the heap cap, non-fatal boot steps, locked atomic channel scrub, case-sensitive cause line, dead light-restart chain removed (fix wave PR 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ All notable changes to AlphaClaw are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow this repository's `package.json` release counter.
 
+## [0.9.77] - 2026-09-04
+
+Fix wave, PR 4 — gateway lifecycle.
+
+### Fixed
+- **Cold restarts dropped the operator's heap cap** (audit F011). The
+  `gateway --force` restart path spawned the new daemon with the CLI env
+  instead of the daemon launch env, so `ALPHACLAW_GATEWAY_MAX_OLD_SPACE_SIZE`
+  applied to the first launch only and vanished after the first restart —
+  while the autotune stamp kept recording the cap the gateway no longer had.
+  The restart spawn now uses the launch env.
+- **A throwing pre-gateway boot step skipped the gateway launch** (F008).
+  `doSyncPromptFiles`, `reloadEnv`, and `ensureGatewayProxyConfig` ran
+  unguarded between the swallow-and-log steps; an exception (the bare
+  `gogcli/` mkdir inside the prompt-file sync was the live example) fell to
+  the outer catch and `startGateway()` never ran — the one boot path with no
+  watchdog self-heal. Each step is now logged and skipped on failure, and the
+  `gogcli/` mkdir itself is non-fatal.
+- **Channel token scrub wrote openclaw.json unlocked and non-atomically**
+  (F013). After `openclaw channels add`, the token → `${ENV}` rewrite was a
+  raw `readFileSync`/`writeFileSync` pair outside the shared file lock; the
+  proxy-config writer held the lock but still wrote in place. Both now write
+  atomically under the lock, and `lib/server/gateway.js` leaves the
+  config-writers guard allowlist.
+- **Restart cause line defeated by lowercase prose** (F048). The severity
+  pattern was case-insensitive, so any trailing line containing "error" in
+  running text ("last error was a connection error") outranked the real
+  `ERROR …` blocker line, and that prose became the persisted incident
+  summary. Severity tags are now case-sensitive (upper-case words, or an
+  `Error:`-style prefix); the error-shaped-word fallback is unchanged.
+
+### Removed
+- Dead lifecycle code (F007, F014): `attachGatewaySignalHandlers` (superseded
+  by `installCrashGuards` in the lifecycle orchestrator since #8), and the
+  `restartGatewayLight` → `runGatewayLifecycleRestart` light-restart chain
+  (imported by `lib/server.js`, never called). Their unit tests go with them;
+  `stampOpenclawConfigConsumed` stays in autotune.
+
+### Notes
+- Tests: `gateway.test.js` (heap cap on cold restart; atomic config writes
+  through a rename-aware fs mock), `startup.test.js` (throwing steps never
+  skip the gateway), `onboarding-workspace.test.js` (unwritable gogcli dir),
+  `restart-hardening-units.test.js` (F048 cases), config-writers guard
+  allowlist shrinks by one.
+
 ## [0.9.76] - 2026-09-04
 
 Fix wave, PR 3 — the agent-admin manifest and what the agent is allowed to see.

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ The built-in watchdog monitors gateway health and recovers from failures automat
 
 ### Gateway prelaunch hook
 
-Opt-in: `ALPHACLAW_GATEWAY_PRELAUNCH_HOOK=/absolute/path/to/executable` (deployment environment only — never honored from `.env`). When set, AlphaClaw runs the hook and waits for it to exit **before every gateway launch** — the boot start, manual/API restarts, watchdog relaunches and repairs, the in-place light restart — strictly before the plugin preflight or the gateway child import the OpenClaw bundle. Use case: containers whose image cannot bake in a change — restore a runtime patch to the installed OpenClaw, start a sidecar the gateway needs, re-apply a file the platform resets on redeploy.
+Opt-in: `ALPHACLAW_GATEWAY_PRELAUNCH_HOOK=/absolute/path/to/executable` (deployment environment only — never honored from `.env`). When set, AlphaClaw runs the hook and waits for it to exit **before every gateway launch** — the boot start, manual/API restarts, watchdog relaunches and repairs — strictly before the plugin preflight or the gateway child import the OpenClaw bundle. Use case: containers whose image cannot bake in a change — restore a runtime patch to the installed OpenClaw, start a sidecar the gateway needs, re-apply a file the platform resets on redeploy.
 
 Requirements (all enforced, any miss aborts the launch):
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -120,8 +120,6 @@ const {
   setGatewayTcpTransitionHandler,
   startGateway,
   restartGateway: restartGatewayWithReload,
-  attachGatewaySignalHandlers,
-  restartGatewayLight: restartGatewayLightWithReload,
   stopGatewayForShutdown,
   stopGatewayForBackup,
   // The persisted stop evidence recorded by stopGatewayForBackup (pid/port/

--- a/lib/server/gateway.js
+++ b/lib/server/gateway.js
@@ -38,7 +38,7 @@ const {
 } = require("./openclaw-runtime-env");
 const { parsePositiveInt } = require("./utils/number");
 const { isOpenAiCompatApiEnabled } = require("./alphaclaw-config");
-const { withFileLockSync } = require("./utils/safe-file");
+const { withFileLockSync, writeFileAtomic } = require("./utils/safe-file");
 const { applyGatewayAuthEnv } = require("./gateway-credential");
 const { filterGatewayChildEnv } = require("./gateway-env-policy");
 // Namespace require (not destructured) so tests can spy on the module object.
@@ -70,7 +70,6 @@ const kGatewayShutdownStopTimeoutMs = 5 * 1000;
 // slice; the CLI stop keeps the remainder, never less than the floor.
 const kGatewayShutdownProbeTimeoutMs = 1500;
 const kGatewayShutdownStopMinMs = 1000;
-const kGatewayLifecycleCmdTimeoutMs = 90 * 1000;
 // Readiness budget lives in constants.js (env-tunable GATEWAY_RESTART_READY_TIMEOUT,
 // clamped 30-480s, default 300s) so the lifecycle-lock lease, the operation
 // record lifetime, and the watchdog suppression windows can derive from the
@@ -715,7 +714,9 @@ const warnStrippedNodeMemoryFlags = (original, filtered) => {
 // is also the env for every short-lived openclaw CLI child — capping those
 // would starve one-shot commands for no benefit. In-gateway restarts
 // (supervisor-mode handoff) re-exec with the daemon's own env, so the cap
-// survives them.
+// survives them. The cold restart path (runGatewayRestartCmd, `gateway
+// --force`) spawns a NEW daemon and must use this too — it used gatewayEnv()
+// and silently dropped the cap after the first restart (fix wave F011).
 const gatewayLaunchEnv = () => {
   const env = gatewayEnv();
   const capMb = parsePositiveInt(
@@ -1292,31 +1293,6 @@ const runGatewayShortCmd = async (
   }
 };
 
-// In-place recycle via the gateway's own lifecycle command — used by the
-// light restart path when the gateway is already up (no plugin preflight, no
-// cold-start stop/force pipeline).
-const runGatewayLifecycleRestart = async () => {
-  console.log("[alphaclaw] Running: openclaw gateway restart");
-  try {
-    const { stdout } = await execFileAsync("openclaw", ["gateway", "restart"], {
-      env: gatewayEnv(),
-      timeout: kGatewayLifecycleCmdTimeoutMs,
-      encoding: "utf8",
-      signal: gatewayAbortController.signal,
-    });
-    if (stdout.trim()) console.log(`[alphaclaw] ${stdout.trim()}`);
-    // The recycled gateway re-read openclaw.json (concurrency now live) but
-    // kept its original env — flip config rows only, never env rows.
-    try {
-      require("./autotune").stampOpenclawConfigConsumed();
-    } catch {}
-    return true;
-  } catch (e) {
-    logGatewayCmdOutput("restart", e);
-    return false;
-  }
-};
-
 const hasActiveManagedGatewayChild = () =>
   !!(
     gatewayChild &&
@@ -1474,7 +1450,9 @@ const runGatewayRestartCmd = async (
   const stderrTail = createStderrTail();
   const stdoutTail = createStderrTail();
   onStep?.({ step: "launching", status: "running" });
-  const restartChildEnv = gatewayEnv();
+  // Daemon env (with the operator's heap cap), not the CLI env: this spawn IS
+  // the long-running gateway after a cold restart (F011).
+  const restartChildEnv = gatewayLaunchEnv();
   const child = spawn("openclaw", ["gateway", cmd], {
     env: restartChildEnv,
     stdio: ["ignore", "pipe", "pipe"],
@@ -2121,50 +2099,6 @@ const restartGateway = async (reloadEnv, { onStep = null } = {}) => {
   return runGatewayColdStart({ onStep });
 };
 
-// Light restart: when the gateway is already up, `openclaw gateway restart`
-// recycles it in place (no plugin preflight, no cold-start stop/force
-// pipeline); when nothing is listening and no managed child is active, fall
-// back to a managed launch. Callers serialize this via gateway-lifecycle-lock
-// like every other lifecycle entry point.
-const restartGatewayLight = async (reloadEnv) => {
-  reloadEnv();
-  if (await isGatewayRunning()) {
-    // The in-place recycle re-imports the bundle too — the hook gates it.
-    try {
-      await prepareGatewayLaunch({ site: "light restart" });
-    } catch (error) {
-      if (error instanceof GatewayPrelaunchHookError) {
-        console.warn("[alphaclaw] Gateway light restart refused by the prelaunch hook");
-        return;
-      }
-      throw error;
-    }
-    if (await runGatewayLifecycleRestart()) {
-      console.log("[alphaclaw] Gateway light restart complete");
-      return;
-    }
-    console.warn("[alphaclaw] Gateway light restart failed");
-    return;
-  }
-  if (!hasActiveManagedGatewayChild()) {
-    console.log("[alphaclaw] Gateway not running — starting managed process");
-    await launchGatewayProcess();
-  }
-};
-
-const attachGatewaySignalHandlers = () => {
-  // The stop command is async now; exit only after it settles or the process
-  // would die with the gateway still holding the port.
-  const stopThenExit = async () => {
-    try {
-      await runGatewayCmd("stop");
-    } catch {}
-    process.exit(0);
-  };
-  process.on("SIGTERM", stopThenExit);
-  process.on("SIGINT", stopThenExit);
-};
-
 // Quiesce stop for the pre-update backup (issues #11/#18): the gateway is the
 // only writer of the state dir, so pausing it makes the backup's tar walk
 // deterministic — no vanished-file races. Unlike stopGatewayForShutdown this
@@ -2424,7 +2358,9 @@ const ensureGatewayProxyConfig = (origin) => {
         const jsonPlaceholder = JSON.stringify(placeholderAuth);
         content = content.split(jsonValue).join(jsonPlaceholder);
       }
-      fs.writeFileSync(configPath, content);
+      // Atomic under the same lock: a torn openclaw.json is a wiped gateway
+      // config on the next fail-open reader (F013).
+      writeFileAtomic(configPath, content, { fsModule: fs });
       invalidateOpenclawConfigMemo();
     }
     return changed;
@@ -2434,6 +2370,28 @@ const ensureGatewayProxyConfig = (origin) => {
     return false;
   }
 };
+
+// Token → ${ENV} scrub after `openclaw channels add` wrote the literal token
+// into openclaw.json. Locked (the team-mode and proxy-config writers share
+// the file lock) and atomic — the previous raw readFileSync/writeFileSync pair
+// raced cross-process writers and could leave a torn file (F013). A text
+// replace, not a JSON walk: the file was just written by openclaw and must be
+// left byte-identical apart from the token occurrences.
+const scrubTokensInOpenclawConfig = (configPath, replacements) =>
+  withFileLockSync(configPath, () => {
+    let raw = fs.readFileSync(configPath, "utf8");
+    let changed = false;
+    for (const { value, envKey } of replacements) {
+      if (!value || !raw.includes(value)) continue;
+      raw = raw.split(value).join("${" + envKey + "}");
+      changed = true;
+    }
+    if (changed) {
+      writeFileAtomic(configPath, raw, { fsModule: fs });
+      invalidateOpenclawConfigMemo();
+    }
+    return changed;
+  });
 
 // Sequential per channel (each add rewrites openclaw.json, and the token →
 // env-ref rewrite must happen right after its own add), but async: each CLI
@@ -2475,15 +2433,10 @@ const syncChannelConfig = async (savedVars, mode = "all") => {
               "--app-token",
               appToken,
             ]);
-            let raw = fs.readFileSync(configPath, "utf8");
-            if (raw.includes(token)) {
-              raw = raw.split(token).join("${" + def.envKey + "}");
-            }
-            if (raw.includes(appToken)) {
-              raw = raw.split(appToken).join("${" + def.extraEnvKeys[0] + "}");
-            }
-            fs.writeFileSync(configPath, raw);
-            invalidateOpenclawConfigMemo();
+            scrubTokensInOpenclawConfig(configPath, [
+              { value: token, envKey: def.envKey },
+              { value: appToken, envKey: def.extraEnvKeys[0] },
+            ]);
           } else {
             await execChannelCmd([
               "channels",
@@ -2493,13 +2446,7 @@ const syncChannelConfig = async (savedVars, mode = "all") => {
               "--token",
               token,
             ]);
-            const raw = fs.readFileSync(configPath, "utf8");
-            if (raw.includes(token)) {
-              fs.writeFileSync(
-                configPath,
-                raw.split(token).join("${" + def.envKey + "}"),
-              );
-            }
+            scrubTokensInOpenclawConfig(configPath, [{ value: token, envKey: def.envKey }]);
           }
           console.log(`[alphaclaw] Channel ${ch} added`);
         } catch (e) {
@@ -2701,8 +2648,6 @@ module.exports = {
   abortGatewayWaits,
   startGateway,
   restartGateway,
-  restartGatewayLight,
-  attachGatewaySignalHandlers,
   stopGatewayForShutdown,
   stopGatewayForBackup,
   getLastGatewayStopEvidence,

--- a/lib/server/onboarding/workspace.js
+++ b/lib/server/onboarding/workspace.js
@@ -513,7 +513,14 @@ const ensureOpenclawRuntimeArtifacts = ({
 
   const gogConfigFile = path.join(openclawDir, "gogcli", "config.json");
   if (!fs.existsSync(gogConfigFile)) {
-    fs.mkdirSync(path.join(openclawDir, "gogcli"), { recursive: true });
+    // Non-fatal (F008): this was the only throw path in the boot's prompt-file
+    // sync, and it aborted the gateway launch when gogcli/ was unwritable.
+    try {
+      fs.mkdirSync(path.join(openclawDir, "gogcli"), { recursive: true });
+    } catch (error) {
+      console.log(`[alphaclaw] gogcli dir skipped: ${error.message}`);
+      return;
+    }
     try {
       execSync("gog auth keyring file", { stdio: "ignore" });
       console.log("[alphaclaw] gog keyring configured (file backend)");

--- a/lib/server/startup.js
+++ b/lib/server/startup.js
@@ -109,8 +109,20 @@ const runOnboardedBootSequence = async ({
         `[alphaclaw] Failed to ensure webhook mapping IDs on boot: ${error.message}`,
       );
     }
-    doSyncPromptFiles();
-    reloadEnv();
+    // Every pre-gateway step is swallow-and-log (F008): a throw here used to
+    // fall through to the outer catch and skip startGateway() entirely — the
+    // one boot path with no watchdog self-heal — e.g. an unwritable gogcli
+    // dir inside doSyncPromptFiles → ensureOpenclawRuntimeArtifacts.
+    try {
+      doSyncPromptFiles();
+    } catch (error) {
+      console.error(`[alphaclaw] Boot prompt-file sync failed: ${error.message}`);
+    }
+    try {
+      reloadEnv();
+    } catch (error) {
+      console.error(`[alphaclaw] Boot env reload failed: ${error.message}`);
+    }
     // A channel-sync failure is logged but never aborts the boot — the
     // gateway can run on its prior channel config.
     try {
@@ -118,7 +130,11 @@ const runOnboardedBootSequence = async ({
     } catch (error) {
       console.error(`[alphaclaw] Boot channel sync failed: ${error.message}`);
     }
-    ensureGatewayProxyConfig(resolveSetupUrl());
+    try {
+      ensureGatewayProxyConfig(resolveSetupUrl());
+    } catch (error) {
+      console.error(`[alphaclaw] Boot gateway proxy config failed: ${error.message}`);
+    }
     // Settings/DB reconciliation BEFORE the gateway can start on the newly
     // activated build (issue #20: the old fail-open path let the gateway
     // crash-loop on an un-migrated config, and the update ledger showed a

--- a/lib/server/utils/cause-line.js
+++ b/lib/server/utils/cause-line.js
@@ -24,7 +24,11 @@ const kBenignLinePatterns = [
 // 2026-09-01 tail the real blocker was an "ERROR ..." line followed by
 // retry/progress chatter that also contained lock-ish words — the last
 // severity-tagged line is the cause, not the last vaguely-errorish one.
-const kSeverityLinePattern = /(^|\s)(ERROR|FATAL|PANIC|ERR!?)\b|\b(error|fatal|panic):/i;
+// Case-SENSITIVE on purpose (F048): with /i, any trailing prose containing a
+// lowercase "error" ("last error was a connection error") outranked the real
+// "ERROR ..." blocker line. A tag is an upper-case word or a "Error:"/"error:"
+// prefix with the colon — not the word in running text.
+const kSeverityLinePattern = /(^|\s)(ERROR|FATAL|PANIC|ERR!?)\b|\b(?:[Ee]rror|[Ff]atal|[Pp]anic):/;
 
 const pickCauseLine = (redactedTail) => {
   const text = String(redactedTail ?? "");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.76",
+  "version": "0.9.77",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alphaclaw",
-      "version": "0.9.76",
+      "version": "0.9.77",
       "license": "MIT",
       "dependencies": {
         "compression": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.76",
+  "version": "0.9.77",
   "publishConfig": {
     "access": "public"
   },

--- a/tests/server/gateway.test.js
+++ b/tests/server/gateway.test.js
@@ -45,6 +45,41 @@ const originalReadFileSync = fs.readFileSync;
 const originalRmSync = fs.rmSync;
 const originalWriteFileSync = fs.writeFileSync;
 const originalFstatSync = fs.fstatSync;
+const originalOpenSync = fs.openSync;
+const originalFsyncSync = fs.fsyncSync;
+const originalCloseSync = fs.closeSync;
+const originalUnlinkSync = fs.unlinkSync;
+const originalRenameSync = fs.renameSync;
+
+// Fix wave F013: openclaw.json writers go through writeFileAtomic (temp file →
+// fsync → rename). Tests that used to capture `fs.writeFileSync(configPath)`
+// now capture the RENAME onto configPath; every other fs call delegates to the
+// real module so the shared file lock keeps working. Returns the write spy.
+const kAtomicMockFd = 987654321;
+const mockAtomicConfigWrites = (onWrite = () => {}) => {
+  const pending = new Map();
+  const configWrite = vi.fn(onWrite);
+  fs.mkdirSync = vi.fn();
+  fs.writeFileSync = vi.fn((targetPath, contents) => {
+    pending.set(String(targetPath), contents);
+  });
+  fs.openSync = vi.fn((targetPath, ...rest) =>
+    pending.has(String(targetPath)) ? kAtomicMockFd : originalOpenSync(targetPath, ...rest),
+  );
+  fs.fsyncSync = vi.fn((fd) => (fd === kAtomicMockFd ? undefined : originalFsyncSync(fd)));
+  fs.closeSync = vi.fn((fd) => (fd === kAtomicMockFd ? undefined : originalCloseSync(fd)));
+  fs.unlinkSync = vi.fn((targetPath) => {
+    if (pending.delete(String(targetPath))) return undefined;
+    return originalUnlinkSync(targetPath);
+  });
+  fs.renameSync = vi.fn((from, to) => {
+    if (!pending.has(String(from))) return originalRenameSync(from, to);
+    const contents = pending.get(String(from));
+    pending.delete(String(from));
+    return configWrite(String(to), contents);
+  });
+  return configWrite;
+};
 const originalCreateConnection = net.createConnection;
 const originalPrelaunchHookEnv = process.env.ALPHACLAW_GATEWAY_PRELAUNCH_HOOK;
 // Namespace-required by gateway.js so the live-process scan can be pinned.
@@ -131,6 +166,11 @@ describe("server/gateway restart behavior", () => {
     fs.rmSync = originalRmSync;
     fs.writeFileSync = originalWriteFileSync;
     fs.fstatSync = originalFstatSync;
+    fs.openSync = originalOpenSync;
+    fs.fsyncSync = originalFsyncSync;
+    fs.closeSync = originalCloseSync;
+    fs.unlinkSync = originalUnlinkSync;
+    fs.renameSync = originalRenameSync;
     net.createConnection = originalCreateConnection;
     if (originalPrelaunchHookEnv === undefined) {
       delete process.env.ALPHACLAW_GATEWAY_PRELAUNCH_HOOK;
@@ -485,6 +525,44 @@ describe("server/gateway restart behavior", () => {
     );
   });
 
+  it("keeps ALPHACLAW_GATEWAY_MAX_OLD_SPACE_SIZE on the cold-restart spawn (F011)", async () => {
+    const previousCap = process.env.ALPHACLAW_GATEWAY_MAX_OLD_SPACE_SIZE;
+    process.env.ALPHACLAW_GATEWAY_MAX_OLD_SPACE_SIZE = "4096";
+    try {
+      const restartSupervisor = createChild();
+      let gatewayPortOpen = false;
+      const spawnMock = vi.fn((file, args) => {
+        if (args?.[0] === "gateway" && args?.[1] === "--force") {
+          queueMicrotask(() => {
+            gatewayPortOpen = true;
+          });
+        }
+        return restartSupervisor;
+      });
+      childProcess.spawn = spawnMock;
+      childProcess.execSync = vi.fn(() => "");
+      fs.existsSync = vi.fn(() => true);
+      net.createConnection = vi.fn(() => createSocket(() => gatewayPortOpen));
+      delete require.cache[modulePath];
+      const gateway = require(modulePath);
+      fs.readFileSync = vi.fn(() =>
+        JSON.stringify({ agents: { defaults: { model: { primary: "openai/gpt-5.1-codex" } } } }),
+      );
+
+      await gateway.restartGateway(vi.fn());
+
+      const forceCall = spawnMock.mock.calls.find(([, args]) => args?.[1] === "--force");
+      expect(forceCall).toBeTruthy();
+      // The daemon spawned by the cold restart carries the operator's cap...
+      expect(forceCall[2].env.NODE_OPTIONS).toMatch(/--max-old-space-size=4096/);
+      // ...while the short-lived CLI env stays uncapped.
+      expect(gateway.gatewayEnv().NODE_OPTIONS ?? "").not.toMatch(/max-old-space-size=4096/);
+    } finally {
+      if (previousCap === undefined) delete process.env.ALPHACLAW_GATEWAY_MAX_OLD_SPACE_SIZE;
+      else process.env.ALPHACLAW_GATEWAY_MAX_OLD_SPACE_SIZE = previousCap;
+    }
+  });
+
   it("retries channel plugin preflight after cleaning stale install stages", async () => {
     const firstError = new Error(
       "ENOTEMPTY: directory not empty, rmdir '/app/node_modules/openclaw/dist/extensions/telegram/.openclaw-install-stage/node_modules/typebox/build/type/engine'",
@@ -798,7 +876,7 @@ describe("server/gateway restart behavior", () => {
       gateway: {},
     };
     fs.existsSync = vi.fn((targetPath) => targetPath === kOnboardingMarkerPath);
-    fs.writeFileSync = vi.fn((targetPath, contents) => {
+    const configWrite = mockAtomicConfigWrites((targetPath, contents) => {
       if (targetPath === `${OPENCLAW_DIR}/openclaw.json`) {
         currentConfig = JSON.parse(contents);
       }
@@ -815,7 +893,7 @@ describe("server/gateway restart behavior", () => {
     const changed = gateway.ensureGatewayProxyConfig("https://setup.example.com");
 
     expect(changed).toBe(true);
-    expect(fs.writeFileSync).toHaveBeenCalledWith(
+    expect(configWrite).toHaveBeenCalledWith(
       `${OPENCLAW_DIR}/openclaw.json`,
       expect.any(String),
     );
@@ -836,7 +914,7 @@ describe("server/gateway restart behavior", () => {
       },
     };
     fs.existsSync = vi.fn((targetPath) => targetPath === kOnboardingMarkerPath);
-    fs.writeFileSync = vi.fn((targetPath, contents) => {
+    const configWrite = mockAtomicConfigWrites((targetPath, contents) => {
       if (targetPath === `${OPENCLAW_DIR}/openclaw.json`) {
         currentConfig = JSON.parse(contents);
       }
@@ -860,7 +938,7 @@ describe("server/gateway restart behavior", () => {
       "https://setup.example.com",
     ]);
     expect(currentConfig.gateway.http).toBeUndefined();
-    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+    expect(configWrite).toHaveBeenCalledTimes(1);
   });
 
   it("preserves existing gateway endpoint options while enabling opted-in public API endpoints", () => {
@@ -883,7 +961,7 @@ describe("server/gateway restart behavior", () => {
       },
     };
     fs.existsSync = vi.fn((targetPath) => targetPath === kOnboardingMarkerPath);
-    fs.writeFileSync = vi.fn((targetPath, contents) => {
+    const configWrite = mockAtomicConfigWrites((targetPath, contents) => {
       if (targetPath === `${OPENCLAW_DIR}/openclaw.json`) {
         currentConfig = JSON.parse(contents);
       }
@@ -944,7 +1022,7 @@ describe("server/gateway restart behavior", () => {
       let currentConfig = initial;
       let lastRawContents = null;
       fs.existsSync = vi.fn((targetPath) => targetPath === kOnboardingMarkerPath);
-      fs.writeFileSync = vi.fn((targetPath, contents) => {
+      const configWrite = mockAtomicConfigWrites((targetPath, contents) => {
         if (targetPath === `${OPENCLAW_DIR}/openclaw.json`) {
           lastRawContents = contents;
           currentConfig = JSON.parse(contents);
@@ -960,6 +1038,7 @@ describe("server/gateway restart behavior", () => {
       });
       return {
         gateway,
+        configWrite,
         getConfig: () => currentConfig,
         getRawContents: () => lastRawContents,
       };
@@ -1114,7 +1193,7 @@ describe("server/gateway restart behavior", () => {
 
           expect(firstChanged).toBe(true);
           expect(secondChanged).toBe(false);
-          expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+          expect(io.configWrite).toHaveBeenCalledTimes(1);
         },
       );
     });
@@ -2319,33 +2398,6 @@ describe("server/gateway restart behavior", () => {
       );
     });
 
-    it("attaches signal handlers that stop the gateway and exit", async () => {
-      childProcess.execFile = execFileOk("");
-      delete require.cache[modulePath];
-      const gateway = require(modulePath);
-      const onSpy = vi.spyOn(process, "on").mockImplementation(() => process);
-      const exitSpy = vi.spyOn(process, "exit").mockImplementation(() => undefined);
-
-      gateway.attachGatewaySignalHandlers();
-
-      const sigterm = onSpy.mock.calls.find((c) => c[0] === "SIGTERM")[1];
-      const sigint = onSpy.mock.calls.find((c) => c[0] === "SIGINT")[1];
-      // Handlers stop the gateway asynchronously before exiting.
-      await sigterm();
-      await sigint();
-
-      expect(exitSpy).toHaveBeenCalledTimes(2);
-      expect(exitSpy).toHaveBeenCalledWith(0);
-      expect(childProcess.execFile).toHaveBeenCalledWith(
-        "openclaw",
-        ["gateway", "stop"],
-        expect.objectContaining({ encoding: "utf8" }),
-        expect.any(Function),
-      );
-      onSpy.mockRestore();
-      exitSpy.mockRestore();
-    });
-
     it("stopGatewayForShutdown reaps the child and best-effort stops external gateways through the shared stop runner", async () => {
       // The lifecycle orchestrator awaits this during graceful shutdown
       // (instead of the plain SIGTERM/SIGINT handlers). The former raw
@@ -2629,58 +2681,6 @@ describe("server/gateway restart behavior", () => {
 
       expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
       expect(reaped).toBe(true);
-    });
-
-    it("uses lifecycle restart for light restarts while the gateway is up", async () => {
-      const behaviors = [
-        (cb) => cb(null, "restarted ok\n", ""),
-        (cb) => {
-          const error = new Error("restart failed");
-          cb(error, "", "restart failed hard");
-        },
-      ];
-      const execFileMock = vi.fn((file, args, opts, cb) =>
-        behaviors.shift()(cb),
-      );
-      childProcess.execFile = execFileMock;
-      net.createConnection = vi.fn(() => createSocket(true));
-      delete require.cache[modulePath];
-      const gateway = require(modulePath);
-      const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      const reloadEnv = vi.fn();
-
-      await gateway.restartGatewayLight(reloadEnv);
-      await gateway.restartGatewayLight(reloadEnv);
-
-      expect(reloadEnv).toHaveBeenCalledTimes(2);
-      expect(execFileMock).toHaveBeenCalledWith(
-        "openclaw",
-        ["gateway", "restart"],
-        expect.objectContaining({ timeout: 90000 }),
-        expect.any(Function),
-      );
-      expect(logSpy).toHaveBeenCalledWith(
-        "[alphaclaw] Gateway light restart complete",
-      );
-      expect(warnSpy).toHaveBeenCalledWith("[alphaclaw] Gateway light restart failed");
-    });
-
-    it("launches a managed process for light restarts when nothing is running", async () => {
-      const child = createChild();
-      childProcess.spawn = vi.fn(() => child);
-      childProcess.execFile = execFileOk("");
-      fs.existsSync = vi.fn(() => false);
-      net.createConnection = vi.fn(() => createSocket(false));
-      delete require.cache[modulePath];
-      const gateway = require(modulePath);
-
-      await gateway.restartGatewayLight(vi.fn());
-      expect(childProcess.spawn).toHaveBeenCalledTimes(1);
-
-      // The managed child is still active, so a second light restart is a no-op.
-      await gateway.restartGatewayLight(vi.fn());
-      expect(childProcess.spawn).toHaveBeenCalledTimes(1);
     });
 
     it("stops the supervisor when a restart never becomes ready", async () => {
@@ -4327,7 +4327,7 @@ describe("server/gateway restart behavior", () => {
         gateway.setGatewayPrelaunchHookHandler(null);
       });
 
-      it("runGatewayCmd('--force') and the in-place light restart are gated by the hook too", async () => {
+      it("runGatewayCmd('--force') is gated by the hook too", async () => {
         pinFstatUid(1000);
         childProcess.spawn = vi.fn(() => createChild());
         childProcess.execFile = vi.fn((file, args, opts, cb) => cb(null, "", ""));
@@ -4346,20 +4346,11 @@ describe("server/gateway restart behavior", () => {
           code: "not_root_owned",
         });
         expect(childProcess.spawn).not.toHaveBeenCalled();
-
-        await gateway.restartGatewayLight(vi.fn());
-        expect(warnSpy).toHaveBeenCalledWith(
-          "[alphaclaw] Gateway light restart refused by the prelaunch hook",
-        );
-        expect(childProcess.execFile).not.toHaveBeenCalledWith(
-          "openclaw",
-          ["gateway", "restart"],
-          expect.anything(),
-          expect.any(Function),
+        expect(warnSpy).not.toHaveBeenCalledWith(
+          expect.stringContaining("light restart"),
         );
         expect(handler.mock.calls.map(([outcome]) => outcome.site)).toEqual([
           "force restart",
-          "light restart",
         ]);
         gateway.setGatewayPrelaunchHookHandler(null);
       });
@@ -4556,7 +4547,7 @@ describe("server/gateway restart behavior", () => {
         if (targetPath === configPath) return state.raw;
         return originalReadFileSync(targetPath, ...args);
       });
-      fs.writeFileSync = vi.fn((targetPath, contents) => {
+      mockAtomicConfigWrites((targetPath, contents) => {
         if (targetPath === configPath) state.raw = contents;
       });
       return state;

--- a/tests/server/guards/config-writers.guard.test.js
+++ b/tests/server/guards/config-writers.guard.test.js
@@ -19,8 +19,6 @@ const kKnownOffenders = {
   "lib/server/onboarding/openclaw.js::configPath": "PR 7: sanitize/ensure writers → updateOpenclawConfig",
   // PR 7 — exec-approvals file-era writer.
   "lib/server/exec-defaults-config.js::filePath": "PR 7: exec-approvals.json → writeFileAtomic",
-  // PR 4 — gateway token→${ENV} scrub and channel sync (F013).
-  "lib/server/gateway.js::configPath": "PR 4: syncChannelConfig scrub → updateOpenclawConfig",
   // Deliberate: the CLI restore copies the git-tracked bytes verbatim into a
   // MISSING openclaw.json — there is nothing to fail closed on. Keep raw.
   "lib/cli/openclaw-config-restore.js::configPath": "intentional: verbatim restore of a missing file",

--- a/tests/server/onboarding-workspace.test.js
+++ b/tests/server/onboarding-workspace.test.js
@@ -1111,6 +1111,25 @@ describe("server/onboarding/workspace bootstrap prompt sync", () => {
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("was a regular file"));
   });
 
+  it("an unwritable gogcli dir is logged, never thrown (F008 — it used to abort the gateway launch)", () => {
+    const openclawDir = "/tmp/alphaclaw-artifacts";
+    const envFilePath = "/tmp/alphaclaw-env-file";
+    const mockFs = {
+      existsSync: vi.fn((target) => target === path.join(openclawDir, ".env") || target === envFilePath),
+      lstatSync: vi.fn(() => ({ isSymbolicLink: () => true, isFile: () => false })),
+      renameSync: vi.fn(),
+      symlinkSync: vi.fn(),
+      mkdirSync: vi.fn(() => {
+        throw Object.assign(new Error("EACCES: permission denied, mkdir"), { code: "EACCES" });
+      }),
+    };
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    expect(() => ensureOpenclawRuntimeArtifacts({ fs: mockFs, openclawDir, envFilePath })).not.toThrow();
+    expect(mockFs.mkdirSync).toHaveBeenCalledWith(path.join(openclawDir, "gogcli"), { recursive: true });
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("gogcli dir skipped: EACCES"));
+    log.mockRestore();
+  });
+
   it("leaves an existing managed symlink alone", () => {
     const openclawDir = "/tmp/alphaclaw-artifacts";
     const envFilePath = "/tmp/alphaclaw-env-file";

--- a/tests/server/restart-hardening-units.test.js
+++ b/tests/server/restart-hardening-units.test.js
@@ -117,6 +117,27 @@ describe("pickCauseLine (no last-line fallback)", () => {
     );
     expect(pickCauseLine("open /data/x: EACCES")).toBe("open /data/x: EACCES");
   });
+
+  it("a trailing lowercase 'error' in prose does not outrank the real ERROR blocker (F048)", () => {
+    const tail = [
+      "ERROR: stale state-lifecycle lock held by pid 4242",
+      "restart attempt 2 did not finish before the deadline; last error was a connection error",
+    ].join("\n");
+    expect(pickCauseLine(tail)).toBe("ERROR: stale state-lifecycle lock held by pid 4242");
+  });
+
+  it("still treats 'Error:'/'error:' prefixes as severity tags, and falls back to error-shaped words", () => {
+    expect(
+      pickCauseLine("ERROR first blocker\nError: listen EADDRINUSE :18789"),
+    ).toBe("Error: listen EADDRINUSE :18789");
+    expect(pickCauseLine("ERR! npm failed\nfatal: not a git repository")).toBe(
+      "fatal: not a git repository",
+    );
+    // No severity tag anywhere → the last error-shaped line still wins.
+    expect(pickCauseLine("warming up\nconnection refused by upstream")).toBe(
+      "connection refused by upstream",
+    );
+  });
 });
 
 describe("evidence redaction composition", () => {

--- a/tests/server/startup.test.js
+++ b/tests/server/startup.test.js
@@ -163,6 +163,36 @@ describe("server/startup", () => {
     ...overrides,
   });
 
+  it("a throwing prompt-file sync, env reload, or proxy-config step never skips the gateway launch (F008)", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const deps = createBootDeps({
+      doSyncPromptFiles: vi.fn(() => {
+        throw new Error("EACCES: mkdir gogcli");
+      }),
+      reloadEnv: vi.fn(() => {
+        throw new Error("env reload broke");
+      }),
+      ensureGatewayProxyConfig: vi.fn(() => {
+        throw new Error("proxy config broke");
+      }),
+    });
+
+    await runOnboardedBootSequence(deps);
+
+    expect(deps.syncChannelConfig).toHaveBeenCalledTimes(1);
+    expect(deps.startGateway).toHaveBeenCalledTimes(1);
+    expect(deps.watchdog.start).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[alphaclaw] Boot prompt-file sync failed: EACCES: mkdir gogcli",
+    );
+    expect(errorSpy).toHaveBeenCalledWith("[alphaclaw] Boot env reload failed: env reload broke");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[alphaclaw] Boot gateway proxy config failed: proxy config broke",
+    );
+    expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("Boot sequence failed"));
+    errorSpy.mockRestore();
+  });
+
   it("logs and continues when the ensure steps fail", async () => {
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const deps = createBootDeps({


### PR DESCRIPTION
Fix wave, PR 4 of the sequence (stacked on #63 → #62 → #61 → #60; merges into `kolkata-v4-pr3`). Audit batch 13: gateway lifecycle. Version **0.9.77**.

## What changed

### Cold restart keeps the heap cap (F011, P2)
`runGatewayRestartCmd` (the `gateway --force` path every manual/API/watchdog restart goes through) spawned the new daemon with `gatewayEnv()` — the short-lived CLI env — so `ALPHACLAW_GATEWAY_MAX_OLD_SPACE_SIZE` applied to the first launch only and vanished after the first restart, while `stampAutotuneFromChildEnv` kept recording a cap the gateway no longer had. It now uses `gatewayLaunchEnv()`. Test: a restart spawn's `NODE_OPTIONS` carries the cap; the CLI env stays uncapped.

### A throwing pre-gateway step no longer skips the gateway (F008, P3)
`doSyncPromptFiles()`, `reloadEnv()`, and `ensureGatewayProxyConfig()` ran unguarded between the swallow-and-log boot steps. An exception (the bare `gogcli/` mkdir inside the prompt-file sync was the live example) fell through to the outer catch and `startGateway()` never ran — the one boot path with no watchdog self-heal. Each step is now logged and skipped; the `gogcli/` mkdir in `ensureOpenclawRuntimeArtifacts` is non-fatal too. Tests: `startup.test.js` (three throwing steps → gateway + watchdog still start), `onboarding-workspace.test.js` (EACCES mkdir → logged, not thrown).

### Channel token scrub: locked + atomic (F013, P3)
After `openclaw channels add`, the token → `${ENV}` rewrite was a raw `readFileSync`/`writeFileSync` pair outside the shared file lock; `ensureGatewayProxyConfig` held the lock but wrote in place. Both now write through `writeFileAtomic` under `withFileLockSync` (`scrubTokensInOpenclawConfig` helper), and `lib/server/gateway.js` leaves the config-writers guard allowlist (guard stale-entry check confirms). Tests capture the rename onto `openclaw.json` via a rename-aware fs mock (`mockAtomicConfigWrites`) instead of `fs.writeFileSync(configPath)`.

### Cause line: severity tags are case-sensitive (F048, P2)
`kSeverityLinePattern` had `/i`, so any trailing prose containing "error" ("last error was a connection error") outranked the real `ERROR …` blocker and became the persisted incident summary. Tags are now upper-case words or an `Error:`/`error:`-style prefix; the error-shaped-word fallback is unchanged. Tests: the reproduction tail, `Error:` prefixes still count, fallback still works.

### Removed dead lifecycle code (F007, F014)
`attachGatewaySignalHandlers` (superseded by `installCrashGuards` in `init/server-lifecycle.js` since #8; kept alive only by its test) and the `restartGatewayLight` → `runGatewayLifecycleRestart` chain (imported by `lib/server.js`, never called). The `kGatewayLifecycleCmdTimeoutMs` constant and the three unit tests go with them; the prelaunch-hook test keeps its `--force` half. `stampOpenclawConfigConsumed` stays in autotune (still tested there).

## Overlap notes
- **Open PR #64 (`louisville`)** touches `lib/server.js` (+9) and `admin-manifest/domains/system.js` (+2 notes) but not `gateway.js`, `startup.js`, or `cause-line.js`. This PR's only `lib/server.js` change removes two lines from the gateway import destructure (far from #64's hunk). PR 5 (watchdog) and PR 6 (release channel) overlap #64 heavily and will sequence behind it.
- **Stale PR #4** (gateway prelaunch hook) was absorbed by #59 (v0.9.71); nothing here conflicts with it, and it can be closed.

## Reconciliation with `origin/main`
`origin/main` is still v0.9.72; no commits landed since the stack's base. Renumber in the final pre-merge commit if that changes.

## Supersedes recent work
- **#59 (v0.9.71, 2026-09-04)** re-touched `gateway.js` (restart hardening); this PR removes `restartGatewayLight`/`runGatewayLifecycleRestart`/`attachGatewaySignalHandlers` from that file — dead since #8/#13, confirmed by grep (only `lib/server.js` imports, never a call). Extension was not possible: the code has no caller.

## Verification
- `npm test` (Node 22, sandbox `OPENCLAW_*` env unset): **445 files, 7187 tests passed**. Config-writers guard: allowlist shrinks by one, no stale entries.
- No `lib/public/js` change → no `build:ui`. Container tier not runnable here (no Docker); CI's Container E2E runs on this PR (it exercises the boot spine and gateway restarts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/897cdaac-c48b-433c-8ab5-3f1ca0b5fe30)
