### PR TITLE
v0.9.80 fix: Telegram/channels/pairings — naming registers discovered topics, non-fatal channel-add restart, scoped env dedupe, quiet workspace repair, verify with the right bot, CLI failures as errors (fix wave PR 8b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to AlphaClaw are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow this repository's `package.json` release counter.
 
+## [0.9.80] - 2026-09-04
+
+Fix wave, PR 8b — Telegram, channel accounts, pairings.
+
+### Fixed
+- **Renaming a discovered Telegram topic never registered it** (audit F090,
+  P1). The topic PUT route spread the existing registry row into its patch,
+  re-asserting `discovered: true` and the cache `nameSource`, which defeated
+  the registry's discovered→registered transition — so a topic the operator
+  named and gave instructions or an agent to stayed "discovered", and its
+  `systemPrompt`/`agentId` never reached openclaw.json. The route now sends a
+  real patch; naming registers the topic and its routing is synced.
+- **Adding a channel account rolled the account back on a slow gateway
+  boot** (F086). `createChannelAccount` treated a ready-timeout from the
+  restart as a failed add and removed the account, restored `.env`, and wrote
+  back a stale whole-config snapshot — while `deleteChannelAccount` already
+  treated the same error as non-fatal. The add now reports
+  `gatewayRestartFailed: true` and keeps the correctly configured account.
+- **Orphaned-token dedupe deleted unrelated env vars** (F091). The "orphaned
+  channel env var" check matched ANY `.env` key by value; a non-channel key
+  holding the same secret was silently dropped. Only channel-shaped keys for
+  that provider qualify now.
+- **Workspace repair loop wrote and git-synced on every load** (F089). With no
+  resolvable human admin the group allow-from repair rewrote openclaw.json and
+  spawned a git-sync per group per page load while changing nothing, and one
+  group's Telegram failure failed the whole read. The repair is skipped with a
+  reason when no admin resolves, and a per-group Telegram error is reported,
+  not thrown.
+- **"Verify now" probed named-account groups with the default bot** (F166).
+  The topic verify API call omitted the account, so a live topic in a
+  named-account group read as stale. The UI passes the account through.
+- **Pairing approve / device reject echoed CLI failures as 200** (F224). The
+  raw `{ ok:false, stdout, stderr }` had no `error` key, so the UI toasted raw
+  JSON or discarded the stderr. Failures answer 502 with the CLI's own words
+  under `error` (`code: cli_failed` / `cli_timeout`).
+
+### Notes
+- Tests: extended `routes-telegram` (F090, F089), `agents-service` (F086,
+  F091), `routes-pairings` (F224), frontend `api` + `telegram-workspace-manage`
+  (F166). `npm run build:ui`.
+
 ## [0.9.79] - 2026-09-04
 
 Fix wave, PR 8a — Google / Gmail and the public origin.

--- a/lib/public/js/components/telegram-workspace/manage.js
+++ b/lib/public/js/components/telegram-workspace/manage.js
@@ -325,7 +325,7 @@ export const ManageTelegramWorkspace = ({
   const handleVerify = async (threadId) => {
     setVerifyingTopicId(String(threadId));
     try {
-      const data = await verifyTelegramTopic(groupId, threadId);
+      const data = await verifyTelegramTopic(groupId, threadId, { accountId });
       if (!data.ok) throw new Error(data.error || "Failed to verify topic");
       // Invalidate any in-flight registry load: a pre-mutation snapshot must
       // not overwrite this optimistic row update.

--- a/lib/public/js/lib/api.js
+++ b/lib/public/js/lib/api.js
@@ -1292,11 +1292,20 @@ export async function restoreTelegramTopic(groupId, topicId) {
   return res.json();
 }
 
-export async function verifyTelegramTopic(groupId, topicId) {
+export async function verifyTelegramTopic(groupId, topicId, { accountId = "" } = {}) {
   const safeGroupId = encodeURIComponent(String(groupId || ""));
   const safeTopicId = encodeURIComponent(String(topicId || ""));
+  // Named-account groups must be probed with THEIR bot (fix wave F166): without
+  // the accountId the server fell back to the default bot, which is not a
+  // member of the group, and "Verify now" marked live topics stale.
+  const params = new URLSearchParams();
+  const normalizedAccountId = String(accountId || "").trim();
+  if (normalizedAccountId && normalizedAccountId !== "default") {
+    params.set("accountId", normalizedAccountId);
+  }
+  const suffix = params.toString() ? `?${params.toString()}` : "";
   const res = await authFetch(
-    `/api/telegram/groups/${safeGroupId}/topics/${safeTopicId}/verify`,
+    `/api/telegram/groups/${safeGroupId}/topics/${safeTopicId}/verify${suffix}`,
     { method: "POST" },
   );
   return res.json();

--- a/lib/server/agents/channels.js
+++ b/lib/server/agents/channels.js
@@ -25,6 +25,8 @@ const {
   hasLegacyDefaultChannelAccount,
   listConfiguredChannelAccounts,
   withNormalizedAgentsConfig,
+  kChannelEnvKeys,
+  kChannelExtraEnvKeys,
 } = require("./shared");
 
 const { createRunStream } = require("../openclaw-run-stream");
@@ -35,6 +37,20 @@ const {
   whenStateDbQuietReleased,
 } = require("../state-db-quiet");
 const { withFileLockSync } = require("../utils/safe-file");
+
+// A key any provider's deriveChannelEnvKey/deriveChannelExtraEnvKeys could have
+// produced (base key, account-suffixed variant, or an extra key) — the only
+// keys the orphan dedupe may treat as a stale channel credential (fix wave
+// F091). Cross-provider on purpose: a token already living in another
+// provider's configured key must still refuse ("already exists in …"), while an
+// unrelated key that happens to hold the same secret is never touched.
+const kChannelEnvKeyStems = [
+  ...Object.values(kChannelEnvKeys),
+  ...Object.values(kChannelExtraEnvKeys).flat(),
+].filter(Boolean);
+const isChannelEnvKeyShape = (key) =>
+  kChannelEnvKeyStems.some((stem) => key === stem || key.startsWith(`${stem}_`));
+
 
 const createChannelsDomain = ({
   fsImpl,
@@ -389,11 +405,15 @@ const createChannelsDomain = ({
       const previousEnvVars = Array.isArray(currentEnvVars)
         ? currentEnvVars
         : [];
+      // Only CHANNEL-shaped keys can be "orphaned channel env vars" (fix wave
+      // F091): matching any .env key by value silently deleted unrelated keys
+      // that happened to hold the same token.
       const duplicateEnvEntry = previousEnvVars.find((entry) => {
         const existingKey = String(entry?.key || "").trim();
         const existingValue = String(entry?.value || "").trim();
         if (!existingKey || !existingValue) return false;
         if (existingKey === envKey) return false;
+        if (!isChannelEnvKeyShape(existingKey)) return false;
         return existingValue === token;
       });
       let orphanedEnvKey = null;
@@ -416,6 +436,7 @@ const createChannelsDomain = ({
           const existingValue = String(entry?.value || "").trim();
           if (!existingKey || !existingValue) return false;
           if (existingKey === envKey || existingKey === appEnvKey) return false;
+          if (!isChannelEnvKeyShape(existingKey)) return false;
           return existingValue === appToken;
         });
         if (duplicateAppTokenEntry) {
@@ -552,8 +573,6 @@ const createChannelsDomain = ({
               "Could not bind channel account",
           );
         }
-        onProgress({ phase: "restarting", label: "Rebooting..." });
-        await restartGateway();
       } catch (error) {
         try {
           await clawCmd(
@@ -580,6 +599,22 @@ const createChannelsDomain = ({
         throw error;
       }
 
+      // The account, env, config and binding are all in place; a gateway
+      // that fails to come back ready is a RESTART problem, not a failed add
+      // (fix wave F086) — deleteChannelAccount already treats it that way.
+      // Rolling back here removed a correctly configured account (and
+      // restored a stale whole-config snapshot) because of a slow boot.
+      let gatewayRestartFailed = false;
+      onProgress({ phase: "restarting", label: "Rebooting..." });
+      try {
+        await restartGateway();
+      } catch (error) {
+        console.warn(
+          `[alphaclaw] gateway restart failed after channel add: ${error.message}`,
+        );
+        gatewayRestartFailed = true;
+      }
+
       const binding = {
         agentId,
         match: normalizeBindingMatch({
@@ -595,6 +630,7 @@ const createChannelsDomain = ({
           envKey,
         },
         binding,
+        ...(gatewayRestartFailed ? { gatewayRestartFailed: true } : {}),
       };
     } finally {
       createChannelAccountInProgress = false;

--- a/lib/server/agents/shared.js
+++ b/lib/server/agents/shared.js
@@ -825,6 +825,8 @@ const ensureAgentScaffold = ({
 };
 
 module.exports = {
+  kChannelEnvKeys,
+  kChannelExtraEnvKeys,
   kDefaultAgentId,
   kChannelTokenFields,
   kChannelLabels,

--- a/lib/server/routes/pairings.js
+++ b/lib/server/routes/pairings.js
@@ -12,6 +12,19 @@ const { logRejectedInput } = require("../utils/input-audit");
 const { isValidChannelAccountId } = require("../agents/shared");
 const { wrapAsync } = require("../utils/wrap-async");
 
+// A failed CLI call used to be echoed back as a 200 `{ ok:false, stdout, stderr }`
+// with no `error` key, so the UI toasted raw JSON or discarded the stderr
+// (fix wave F224). Answer 502 with the CLI's own words under `error`.
+const sendCliFailure = (res, result, fallback) => {
+  const detail = String(result?.stderr || result?.stdout || "").trim();
+  res.status(502).json({
+    ok: false,
+    error: detail || fallback,
+    code: result?.timedOut ? "cli_timeout" : "cli_failed",
+    ...(result?.code != null ? { exitCode: result.code } : {}),
+  });
+};
+
 // ONE source for "which channels pair through AlphaClaw" — the sweep, approve
 // and reject all read it (fix wave F087: reject used to path.join an
 // unvalidated body.channel into credentials/<channel>-pairing.json). Whether
@@ -397,6 +410,7 @@ const registerPairingRoutes = ({
       : `pairing approve ${quoteCliArg(channel)} ${quoteCliArg(pairingId)}`;
     const result = await clawCmd(approveCmd);
     pairingCache.ts = 0;
+    if (!result?.ok) return sendCliFailure(res, result, "pairing approve failed");
     res.json(result);
   }));
 
@@ -557,6 +571,7 @@ const registerPairingRoutes = ({
     }
     const result = await clawCmd(`devices reject ${quoteCliArg(requestId)}`);
     devicePairingCache.ts = 0;
+    if (!result?.ok) return sendCliFailure(res, result, "devices reject failed");
     res.json(result);
   }));
 };

--- a/lib/server/routes/telegram.js
+++ b/lib/server/routes/telegram.js
@@ -178,11 +178,32 @@ const registerTelegramRoutes = ({
     ) {
       return { repaired: false, resolvedUserId: "", syncWarning: null };
     }
-    const resolvedUserId = await resolveAllowUserId({
-      telegramApi: tgApi,
-      groupId,
-      preferredUserId: "",
-    });
+    // Fix wave F089: with no resolvable human admin the sync used to write
+    // openclaw.json and spawn a git-sync on EVERY workspace load while changing
+    // nothing (groupAllowFrom stayed empty). Skip the write entirely; the
+    // caller reports why. A Telegram failure for one group is reported, not
+    // thrown — the rest of the workspace still renders.
+    let resolvedUserId = "";
+    try {
+      resolvedUserId = await resolveAllowUserId({
+        telegramApi: tgApi,
+        groupId,
+        preferredUserId: "",
+      });
+    } catch (error) {
+      return {
+        repaired: false,
+        resolvedUserId: "",
+        syncWarning: `Could not read group admins for ${groupId}: ${error?.message || error}`,
+      };
+    }
+    if (!resolvedUserId) {
+      return {
+        repaired: false,
+        resolvedUserId: "",
+        syncWarning: `No human admin found in ${groupId}; groupAllowFrom left empty`,
+      };
+    }
     syncConfigForTelegram({
       fs,
       openclawDir: OPENCLAW_DIR,
@@ -614,11 +635,16 @@ const registerTelegramRoutes = ({
           }
         }
       }
+      // Send a PATCH, never the spread existing row (fix wave F090): spreading
+      // `existingTopic` re-asserted `discovered: true` and `nameSource: "cache"`
+      // in the patch, which defeated updateTopic's discovered→registered
+      // transition and its nameSource drop — a UI-named discovered topic stayed
+      // discovered, so its systemInstructions/agentId never reached
+      // openclaw.json via syncConfigForTelegram.
       topicRegistry.updateTopic(
         groupId,
         threadId,
         {
-          ...existingTopic,
           name,
           ...(hasSystemInstructions ? { systemInstructions } : {}),
           ...(hasAgentId ? { agentId: agentId || undefined } : {}),
@@ -753,6 +779,9 @@ const registerTelegramRoutes = ({
 
       const tgApi = resolveAccountTelegramApi(accountId, telegramApi);
       let activeGroupIds = useRegistryFallback ? registryFallbackGroupIds : groupIds;
+      // Per-group repair outcomes that did not repair (no admin, Telegram
+      // error) ride on the response instead of failing the whole read (F089).
+      const repairWarnings = [];
       if (!useRegistryFallback) {
         let anyRepaired = false;
         for (const gId of groupIds) {
@@ -766,6 +795,8 @@ const registerTelegramRoutes = ({
           });
           if (repairResult.repaired) {
             anyRepaired = true;
+          } else if (repairResult.syncWarning) {
+            repairWarnings.push({ groupId: gId, warning: repairResult.syncWarning });
           }
         }
         if (anyRepaired) {
@@ -812,6 +843,7 @@ const registerTelegramRoutes = ({
         groupName: first.groupName,
         topics: first.topics,
         debugEnabled,
+        ...(repairWarnings.length ? { repairWarnings } : {}),
         concurrency: (() => {
           // Server-computed values so the client's fallback formula never has
           // to guess the machine-derived cap (lib/server/autotune.js).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alphaclaw",
-      "version": "0.9.79",
+      "version": "0.9.80",
       "license": "MIT",
       "dependencies": {
         "compression": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.79",
+  "version": "0.9.80",
   "publishConfig": {
     "access": "public"
   },

--- a/tests/frontend/api.test.js
+++ b/tests/frontend/api.test.js
@@ -1456,6 +1456,17 @@ describe("frontend/api behaviors", () => {
     expect(result).toEqual({ ok: true, status: "stale" });
   });
 
+  it("verifyTelegramTopic passes a named account through as ?accountId (F166) and omits the default", async () => {
+    global.fetch.mockResolvedValue(mockJsonResponse(200, { ok: true, status: "ok" }));
+    const api = await loadApiModule();
+    await api.verifyTelegramTopic("-100123", 42, { accountId: "work" });
+    expect(global.fetch.mock.calls[0][0]).toBe(
+      "/api/telegram/groups/-100123/topics/42/verify?accountId=work",
+    );
+    await api.verifyTelegramTopic("-100123", 42, { accountId: "default" });
+    expect(global.fetch.mock.calls[1][0]).toBe("/api/telegram/groups/-100123/topics/42/verify");
+  });
+
   it("parseJsonOrThrow rejects when the payload marks ok false", async () => {
     global.fetch.mockResolvedValue(mockJsonResponse(200, { ok: false, error: "nope" }));
     const api = await loadApiModule();

--- a/tests/frontend/telegram-workspace-manage-component.test.js
+++ b/tests/frontend/telegram-workspace-manage-component.test.js
@@ -311,6 +311,8 @@ describe("frontend/telegram-workspace manage component", () => {
     expect(verifyButton).toBeTruthy();
     await verifyButton.props.onclick();
     expect(harness.slots[kRegistryRowsSlot][0].stale).toBe(false);
+    // The probe runs with the group's own bot account (F166).
+    expect(api.verifyTelegramTopic).toHaveBeenCalledWith("-100123", "42", { accountId: "alerts" });
 
     // ...and resolves after it with the pre-mutation snapshot: discarded.
     registryResolvers[0]({ ok: true, topics: [staleRow], discovery: null });

--- a/tests/server/agents-service-coverage.test.js
+++ b/tests/server/agents-service-coverage.test.js
@@ -370,7 +370,10 @@ describe("server/agents/service coverage", () => {
     it("overwrites orphaned env vars that duplicate a new slack app token", async () => {
       const writeEnvFile = vi.fn();
       const { fsMock, service, restartGateway } = buildService({
-        readEnvFile: () => [{ key: "LEGACY_APP_TOKEN", value: "xapp-orphan" }],
+        // A stale channel-shaped key (e.g. left by a removed named account) is an
+        // orphan; an unrelated key holding the same token is NOT (fix wave F091,
+        // see agents-service.test.js).
+        readEnvFile: () => [{ key: "SLACK_APP_TOKEN_LEGACY", value: "xapp-orphan" }],
         writeEnvFile,
       });
 

--- a/tests/server/agents-service.test.js
+++ b/tests/server/agents-service.test.js
@@ -3648,3 +3648,86 @@ describe("server/agents/service", () => {
     });
   });
 });
+
+describe("server/agents-service channel add: restart failure is not a failed add; env dedupe stays in its lane (F086, F091)", () => {
+  const buildService = ({ initialEnv, restartGateway }) => {
+    const fsMock = buildFsMock({
+      initialConfig: { agents: { list: [{ id: "main", default: true }] } },
+    });
+    const writes = [];
+    const readEnvFile = vi.fn(() => initialEnv.map((entry) => ({ ...entry })));
+    const writeEnvFile = vi.fn((next) => writes.push(next.map((entry) => ({ ...entry }))));
+    const clawCmd = vi.fn(async () => ({ ok: true, stdout: "", stderr: "" }));
+    const service = createAgentsService({
+      fs: fsMock,
+      OPENCLAW_DIR: "/tmp/openclaw",
+      readEnvFile,
+      writeEnvFile,
+      reloadEnv: vi.fn(),
+      restartGateway,
+      clawCmd,
+    });
+    return { service, fsMock, writes, clawCmd, writeEnvFile };
+  };
+
+  it("keeps the configured account and reports gatewayRestartFailed when the gateway never becomes ready (F086)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const restartGateway = vi.fn(async () => {
+      throw new Error("Gateway --force did not become ready within 120s");
+    });
+    const { service, fsMock, writes, clawCmd } = buildService({
+      initialEnv: [{ key: "OPENAI_API_KEY", value: "sk-test" }],
+      restartGateway,
+    });
+
+    const result = await service.createChannelAccount({
+      provider: "telegram",
+      name: "Telegram",
+      accountId: "default",
+      token: "123:abc",
+      agentId: "main",
+    });
+
+    expect(result).toMatchObject({ channel: "telegram", gatewayRestartFailed: true });
+    // No rollback: the account stays in openclaw.json, the env keeps the token,
+    // and `channels remove` was never issued.
+    expect(fsMock.readConfig().channels.telegram.accounts.default.botToken).toBe("${TELEGRAM_BOT_TOKEN}");
+    expect(writes.at(-1)).toEqual(
+      expect.arrayContaining([{ key: "TELEGRAM_BOT_TOKEN", value: "123:abc" }]),
+    );
+    expect(clawCmd.mock.calls.some(([cmd]) => String(cmd).startsWith("channels remove"))).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("gateway restart failed after channel add"));
+    warn.mockRestore();
+  });
+
+  it("a non-channel env var holding the same token is NOT treated as an orphan (F091)", async () => {
+    const { service, writes } = buildService({
+      initialEnv: [
+        { key: "OPENAI_API_KEY", value: "sk-test" },
+        // Same secret value under an unrelated key — must survive the add.
+        { key: "MY_BACKUP_OF_THE_BOT_TOKEN", value: "123:abc" },
+        // A stale channel-shaped key for the same provider IS an orphan.
+        { key: "TELEGRAM_BOT_TOKEN_OLDACCOUNT", value: "123:abc" },
+      ],
+      restartGateway: vi.fn(async () => {}),
+    });
+
+    await service.createChannelAccount({
+      provider: "telegram",
+      name: "Telegram",
+      accountId: "default",
+      token: "123:abc",
+      agentId: "main",
+    });
+
+    const finalEnv = writes.at(-1);
+    expect(finalEnv).toEqual(
+      expect.arrayContaining([
+        { key: "OPENAI_API_KEY", value: "sk-test" },
+        { key: "MY_BACKUP_OF_THE_BOT_TOKEN", value: "123:abc" },
+        { key: "TELEGRAM_BOT_TOKEN", value: "123:abc" },
+      ]),
+    );
+    expect(finalEnv.some((entry) => entry.key === "TELEGRAM_BOT_TOKEN_OLDACCOUNT")).toBe(false);
+  });
+});

--- a/tests/server/routes-pairings.test.js
+++ b/tests/server/routes-pairings.test.js
@@ -1430,6 +1430,57 @@ describe("server/routes/pairings", () => {
     expect(res.body).toEqual({ ok: true, requestId: "req-fallback", device: null });
   });
 
+
+  describe("CLI failures surface as errors, never as a 200 with raw stdout/stderr (F224)", () => {
+    it("pairing approve: a failed CLI answers 502 with the CLI's words under `error`", async () => {
+      const clawCmd = vi.fn(async () => ({
+        ok: false,
+        stdout: "",
+        stderr: "Error: pairing request ABCD1234 not found",
+        code: 1,
+      }));
+      const fsModule = { existsSync: vi.fn(() => false), mkdirSync: vi.fn(), writeFileSync: vi.fn() };
+      const app = createApp({ clawCmd, isOnboarded: () => true, fsModule });
+
+      const res = await request(app)
+        .post("/api/pairings/ABCD1234/approve")
+        .send({ channel: "discord" });
+
+      expect(res.status).toBe(502);
+      expect(res.body).toEqual({
+        ok: false,
+        error: "Error: pairing request ABCD1234 not found",
+        code: "cli_failed",
+        exitCode: 1,
+      });
+    });
+
+    it("pairing approve: a timed-out CLI is code cli_timeout with a fallback message", async () => {
+      const clawCmd = vi.fn(async () => ({ ok: false, stdout: "", stderr: "", timedOut: true, code: null }));
+      const fsModule = { existsSync: vi.fn(() => false), mkdirSync: vi.fn(), writeFileSync: vi.fn() };
+      const app = createApp({ clawCmd, isOnboarded: () => true, fsModule });
+      const res = await request(app)
+        .post("/api/pairings/ABCD1234/approve")
+        .send({ channel: "discord" });
+      expect(res.status).toBe(502);
+      expect(res.body).toMatchObject({ ok: false, error: "pairing approve failed", code: "cli_timeout" });
+    });
+
+    it("device reject: a failed CLI answers 502 with `error`; success still echoes the CLI result", async () => {
+      const failing = vi.fn(async () => ({ ok: false, stdout: "", stderr: "no such request", code: 2 }));
+      const fsModule = { existsSync: vi.fn(() => false), mkdirSync: vi.fn(), writeFileSync: vi.fn() };
+      const failApp = createApp({ clawCmd: failing, isOnboarded: () => true, fsModule });
+      const failed = await request(failApp).post(`/api/devices/${"ABCD1234"}/reject`);
+      expect(failed.status).toBe(502);
+      expect(failed.body).toMatchObject({ ok: false, error: "no such request", code: "cli_failed", exitCode: 2 });
+
+      const okCmd = vi.fn(async () => ({ ok: true, stdout: "rejected", stderr: "" }));
+      const okApp = createApp({ clawCmd: okCmd, isOnboarded: () => true, fsModule });
+      const ok = await request(okApp).post(`/api/devices/${"ABCD1234"}/reject`);
+      expect(ok.status).toBe(200);
+      expect(ok.body).toMatchObject({ ok: true, stdout: "rejected" });
+    });
+  });
 });
 
 describe("server/routes/pairings removeAccountRequestsFromPairingStore", () => {

--- a/tests/server/routes-telegram.test.js
+++ b/tests/server/routes-telegram.test.js
@@ -1244,7 +1244,13 @@ describe("server/routes/telegram", () => {
 
       const res = await request(app).get("/api/telegram/workspace");
 
-      expect(res.body).toEqual({ ok: false, error: "admins boom" });
+      // Fix wave F089: one group's Telegram failure no longer fails the whole
+      // read — the workspace renders and the failure is a visible warning.
+      expect(res.body.ok).toBe(true);
+      expect(res.body.groups.map((g) => g.groupId)).toEqual(["-100"]);
+      expect(res.body.repairWarnings).toEqual([
+        { groupId: "-100", warning: expect.stringContaining("admins boom") },
+      ]);
     });
   });
 
@@ -1422,6 +1428,90 @@ describe("server/routes/telegram", () => {
       const res = await request(app).post("/api/telegram/workspace/reset");
 
       expect(res.body).toEqual({ ok: false, error: "prompt sync failed" });
+    });
+  });
+
+  describe("fix wave PR 8b: topic PUT registers discovered topics; workspace repair is quiet without an admin", () => {
+    it("naming a DISCOVERED topic clears discovered + cache nameSource and syncs its routing into openclaw.json (F090)", async () => {
+      writeOpenclawJson({
+        channels: { telegram: { groups: { "-100": { requireMention: true } } } },
+      });
+      writeRegistryFile({
+        version: 2,
+        meta: { sweepWatermark: 0 },
+        groups: {
+          "-100": {
+            name: "G",
+            topics: { 5: { name: "cached name", discovered: true, nameSource: "cache" } },
+          },
+        },
+      });
+      const { app } = createApp();
+
+      const res = await request(app)
+        .put("/api/telegram/groups/-100/topics/5")
+        .send({ name: "Ops", systemInstructions: "Handle ops only.", agentId: "ops" });
+      expect(res.body.ok).toBe(true);
+
+      const stored = readRegistryFile().groups["-100"].topics["5"];
+      expect(stored).toEqual({
+        name: "Ops",
+        systemInstructions: "Handle ops only.",
+        agentId: "ops",
+        discovered: false,
+      });
+      expect(stored.nameSource).toBeUndefined();
+      // The registered topic's routing reached the gateway config.
+      expect(readOpenclawJson().channels.telegram.groups["-100"].topics).toEqual({
+        "5": { systemPrompt: "Handle ops only.", agentId: "ops" },
+      });
+    });
+
+    it("GET workspace does not rewrite openclaw.json or git-sync when no human admin resolves (F089)", async () => {
+      writeOpenclawJson({
+        channels: { telegram: { groups: { "-100": { requireMention: false } } } },
+      });
+      const telegramApi = makeTelegramApi({
+        getChatAdministrators: vi.fn(async () => [
+          { status: "administrator", user: { id: 42, is_bot: true } },
+        ]),
+      });
+      const { app, shellCmd } = createApp({ telegramApi });
+      const before = fs.readFileSync(kOpenclawJsonPath, "utf8");
+
+      const res = await request(app).get("/api/telegram/workspace");
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.groups.map((g) => g.groupId)).toEqual(["-100"]);
+      expect(fs.readFileSync(kOpenclawJsonPath, "utf8")).toBe(before);
+      expect(shellCmd).not.toHaveBeenCalledWith(
+        expect.stringContaining("repair-group-allow-from"),
+        expect.anything(),
+      );
+      expect(res.body.repairWarnings).toEqual([
+        { groupId: "-100", warning: expect.stringContaining("No human admin found") },
+      ]);
+    });
+
+    it("GET workspace survives a Telegram failure for one group's admin lookup (F089)", async () => {
+      writeOpenclawJson({
+        channels: { telegram: { groups: { "-100": {}, "-200": {} } } },
+      });
+      const telegramApi = makeTelegramApi({
+        getChatAdministrators: vi.fn(async (groupId) => {
+          if (String(groupId) === "-100") throw new Error("Bad Request: CHAT_ADMIN_REQUIRED");
+          return [{ status: "creator", user: { id: 7, is_bot: false } }];
+        }),
+      });
+      const { app } = createApp({ telegramApi });
+
+      const res = await request(app).get("/api/telegram/workspace");
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.groups.map((g) => g.groupId).sort()).toEqual(["-100", "-200"]);
+      expect(res.body.repairWarnings).toEqual([
+        { groupId: "-100", warning: expect.stringContaining("CHAT_ADMIN_REQUIRED") },
+      ]);
     });
   });
 });


### PR DESCRIPTION
Fix wave, PR 8b of the sequence (stacked on #67 → #66 → #65 → #63 → #62 → #61 → #60; merges into `kolkata-v4-pr8a`). Audit batch 21: Telegram, channel accounts, pairings. Version **0.9.80**.

## What changed

- **F090 (P1)** — `PUT /api/telegram/groups/:g/topics/:t` spread the existing registry row into its patch, re-asserting `discovered: true` and `nameSource: "cache"`, which defeated `updateTopic`'s discovered→registered transition and its nameSource drop. A UI-named discovered topic stayed discovered, so `syncConfigForTelegram` never wrote its `systemPrompt`/`agentId` into openclaw.json. The route now sends a real patch. Test: discovered+cache-named topic → PUT → registry `{ name, systemInstructions, agentId, discovered: false }` with no `nameSource`, and openclaw.json carries the topic routing.
- **F086** — `createChannelAccount` treated a gateway ready-timeout as a failed add and rolled the account back (CLI `channels remove`, `.env` restore, stale whole-config snapshot); `deleteChannelAccount` already treated the same error as non-fatal. The add now keeps the correctly configured account and returns `gatewayRestartFailed: true` (logged). Test: restart rejects → account/env kept, no `channels remove`.
- **F091** — the "orphaned channel env var" dedupe matched ANY `.env` key by token value and silently deleted unrelated keys. `isChannelEnvKeyShape` restricts it to keys `deriveChannelEnvKey`/`deriveChannelExtraEnvKeys` could produce for that provider. Test: an unrelated key with the same token survives; a stale channel-shaped key is still cleaned up.
- **F089** — `GET /api/telegram/workspace`'s allow-from repair wrote openclaw.json and spawned a git-sync per group per page load when no human admin resolved (changing nothing), and one group's `getChatAdministrators` failure failed the whole read. The repair is skipped with a reason when no admin resolves; a per-group Telegram error is reported, not thrown; both surface as `repairWarnings: [{ groupId, warning }]` on the response. The pinned test that expected `{ ok:false, error:"admins boom" }` now asserts the visible warning instead (deliberate contract change; the response body still names the failure).
- **F166** — "Verify now" omitted the account, so named-account groups were probed with the default bot (not a member) and live topics read as stale. `verifyTelegramTopic(groupId, topicId, { accountId })` appends `?accountId=` for non-default accounts; the manage view passes it. `npm run build:ui` run.
- **F224** — pairing approve and device reject echoed a failed CLI as `200 { ok:false, stdout, stderr }` with no `error`, so six UI surfaces toasted raw JSON or discarded stderr. Failures now answer `502 { ok:false, error: <stderr|stdout|fallback>, code: cli_failed|cli_timeout, exitCode }`; successes are unchanged.

## Overlap / reconciliation
No open PR touches these files (#64 `louisville` is watchdog/channel-sync/system). `origin/main` is still v0.9.72; renumber in the final pre-merge commit if that changes.

## Supersedes recent work
- **#44 (v0.9.58, Telegram topics)** and the v0.9.6x topic-discovery work: the PUT route's patch construction is rewritten (three lines) — the spread was the bug; nothing else from those PRs is removed.

## Verification
- `npm test` (Node 22, sandbox `OPENCLAW_*` env unset): see the final run noted in the PR conversation.
- Extended: `routes-telegram` (+3, one contract update), `agents-service` (+2), `routes-pairings` (+3), frontend `api` (+1), `telegram-workspace-manage-component` (+1 assertion).
- Container tier not runnable here (no Docker); CI's Container E2E runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/897cdaac-c48b-433c-8ab5-3f1ca0b5fe30)
