### PR TITLE
v0.9.81 fix: server misc — 1+N usage scans, webhook log retention, models payload validation, autotune revert recovery, cache-read pricing, Google/team input checks (fix wave PR 8c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to AlphaClaw are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow this repository's `package.json` release counter.
 
+## [0.9.81] - 2026-09-04
+
+Fix wave, PR 8c — server odds and ends.
+
+### Fixed
+- **Usage tab issued 1+N full-table scans** (audit F076). `getSessionsList`
+  re-prepared and ran an unindexable per-session events query for every row
+  (up to 200 per open), blocking the event loop in proportion to install age.
+  One events read now serves every selected session (per-event costing kept —
+  tiered pricing depends on each event's token count), and the session-ref
+  predicate has an expression index.
+- **Webhook request log grew without bound** (F155). Pruning was age-only
+  (boot + 12h) while the summary query ranked the whole table on every 15s
+  list poll. Inserts now keep the newest 500 rows per hook; the age prune still
+  runs.
+- **`PUT /api/models/config` validated after writing** (F078, F212). Arrays
+  passed the `configuredModels`/`authOrder` object guards and landed in
+  openclaw.json; a `null` profile entry 500ed after the model config was
+  already written (partial apply, catalog cache not marked stale); `type` was
+  never checked. The whole payload is validated first: 400 names the offending
+  `profiles[i]` field, nothing is written.
+- **Autotune revert ignored a crash-window stale intent** (F082). The enable
+  path recovers "our write landed, the confirm did not"; the disable/kill-switch
+  revert did not, so it left autotune's own `maxConcurrent` in openclaw.json
+  and deleted its provenance. Both paths now treat a matching stale intent as
+  autotune-owned.
+- **Cache-read tokens billed at $0** for the static fallback models that omit
+  `cacheRead` (F083); they now fall back to 10% of the input rate (the
+  provider-documented ratio), matching the existing cache-write fallback.
+- `/auth/google/start` 500ed on a repeated/bracketed `services` query key
+  (F209); `PATCH /api/team/members/:id` disabled a member on the string
+  `"false"` (F210) — `disabled` must be a boolean, `displayName` a string.
+
+### Notes
+- Deferred behind PR #64 (same file, `routes/system.js`): F077 (`/api/agent/
+  message` 15s timeout), F081 (`fetchGitHubRelease` never settles on a
+  mid-body close), F208 (`PUT /api/env` null element).
+- Tests: extended `webhooks-db`, `usage-db`, `routes-models-coverage`,
+  `autotune`, `cost-utils`, `routes-oauth-binding`, `routes-team`.
+
 ## [0.9.80] - 2026-09-04
 
 Fix wave, PR 8b — Telegram, channel accounts, pairings.

--- a/lib/server/autotune.js
+++ b/lib/server/autotune.js
@@ -653,8 +653,20 @@ const applyConcurrency = ({ active, derivation, ledger, deps }) => {
         mutate: (cfg) => {
           const current = readCurrent(cfg);
           const confirmed = ownership && !ownership.intent ? ownership : null;
-          const attributable = confirmed && current === confirmed.lastApplied;
-          if (attributable && confirmed.ownedFromAbsent) {
+          // Crash-window recovery on the revert path too (fix wave F082): a
+          // stale intent whose value matches the config means OUR write landed
+          // but the confirm never persisted. The enable path already treats
+          // that as autotune-owned; the revert used to leave the value in
+          // openclaw.json and then delete its provenance.
+          const staleIntent = ownership?.intent || null;
+          const recoveredFromIntent = Boolean(staleIntent && current === staleIntent.value);
+          const attributable =
+            (confirmed && current === confirmed.lastApplied) || recoveredFromIntent;
+          const ownedFromAbsent = confirmed
+            ? confirmed.ownedFromAbsent === true
+            : recoveredFromIntent &&
+              (ownership?.ownedFromAbsent === true || ownership?.lastApplied == null);
+          if (attributable && ownedFromAbsent) {
             if (cfg.agents?.defaults) delete cfg.agents.defaults.maxConcurrent;
             revertChange = { kind: "deleted", from: current ?? null, to: null };
             return {};

--- a/lib/server/cost-utils.js
+++ b/lib/server/cost-utils.js
@@ -325,6 +325,8 @@ const resolvePricingFromFallbackMap = (model = "") => {
   return matchKey ? kGlobalModelPricing[matchKey] : null;
 };
 
+const kCacheReadInputRatioFallback = 0.1;
+
 const resolvePerMillionRate = (rate, tokens) => {
   if (typeof rate === "function") {
     return Number(rate(toInt(tokens)));
@@ -357,10 +359,14 @@ const deriveCostBreakdown = ({
   const outputRate = resolvePerMillionRate(pricing.output, outputTokens);
   const inputCost = (inputTokens / kTokensPerMillion) * inputRate;
   const outputCost = (outputTokens / kTokensPerMillion) * outputRate;
-  const cacheReadRate = resolvePerMillionRate(
-    pricing.cacheRead,
-    cacheReadTokens,
-  );
+  // Fix wave F083: about half the static fallback entries omit cacheRead;
+  // the old code billed those reads at $0 (cacheWrite already fell back to
+  // the input rate). Every major provider prices cache reads at ~10% of input
+  // (Anthropic, OpenAI GPT-5 "cached input"), so use that rather than nothing.
+  const cacheReadRate =
+    pricing.cacheRead == null
+      ? resolvePerMillionRate(pricing.input, cacheReadTokens) * kCacheReadInputRatioFallback
+      : resolvePerMillionRate(pricing.cacheRead, cacheReadTokens);
   const cacheReadCost = (cacheReadTokens / kTokensPerMillion) * cacheReadRate;
   const cacheWriteRate = resolvePerMillionRate(
     pricing.cacheWrite == null ? pricing.input : pricing.cacheWrite,

--- a/lib/server/db/usage/schema.js
+++ b/lib/server/db/usage/schema.js
@@ -45,6 +45,13 @@ const ensureSchema = (database) => {
   database.exec(`
     CREATE INDEX IF NOT EXISTS idx_usage_events_session_key
     ON usage_events(session_key);
+
+    -- Expression index for the session-ref predicate every session query uses
+    -- (fix wave F076); SQLite matches it only when the expression is byte-
+    -- identical, so keep COALESCE(NULLIF(session_key, ''), NULLIF(session_id, ''))
+    -- spelled exactly like this in sessions.js.
+    CREATE INDEX IF NOT EXISTS idx_usage_events_session_ref
+    ON usage_events(COALESCE(NULLIF(session_key, ''), NULLIF(session_id, '')));
   `);
   database.exec(`
     CREATE TABLE IF NOT EXISTS usage_daily (

--- a/lib/server/db/usage/sessions.js
+++ b/lib/server/db/usage/sessions.js
@@ -32,10 +32,20 @@ const getSessionsList = ({
       LIMIT $limit
     `)
     .all({ $limit: safeLimit });
-  return rows.map((row) => {
+  // ONE events read for every selected session (fix wave F076): the previous
+  // shape re-prepared and ran a full-table scan per session row (1+N, up to
+  // 200 scans per Usage tab open, growing with install age). Per-event costing
+  // is kept — tiered pricing functions depend on each event's token count, so
+  // summing first would change totals.
+  const sessionRefs = rows.map((row) => row.session_ref);
+  const eventsBySession = new Map();
+  if (sessionRefs.length > 0) {
+    const placeholders = sessionRefs.map((_, index) => `$ref${index}`).join(", ");
+    const params = Object.fromEntries(sessionRefs.map((ref, index) => [`$ref${index}`, ref]));
     const eventRows = database
       .prepare(`
         SELECT
+          COALESCE(NULLIF(session_key, ''), NULLIF(session_id, '')) AS session_ref,
           model,
           input_tokens,
           output_tokens,
@@ -43,9 +53,17 @@ const getSessionsList = ({
           cache_write_tokens,
           total_tokens
         FROM usage_events
-        WHERE COALESCE(NULLIF(session_key, ''), NULLIF(session_id, '')) = $sessionRef
+        WHERE COALESCE(NULLIF(session_key, ''), NULLIF(session_id, '')) IN (${placeholders})
       `)
-      .all({ $sessionRef: row.session_ref });
+      .all(params);
+    for (const eventRow of eventRows) {
+      const bucket = eventsBySession.get(eventRow.session_ref);
+      if (bucket) bucket.push(eventRow);
+      else eventsBySession.set(eventRow.session_ref, [eventRow]);
+    }
+  }
+  return rows.map((row) => {
+    const eventRows = eventsBySession.get(row.session_ref) || [];
     let totalCost = 0;
     const modelTokenTotals = new Map();
     for (const eventRow of eventRows) {

--- a/lib/server/db/webhooks/index.js
+++ b/lib/server/db/webhooks/index.js
@@ -12,6 +12,11 @@ const kDefaultRequestLimit = 50;
 const kMaxRequestLimit = 200;
 const kPruneIntervalMs = 12 * 60 * 60 * 1000;
 const kHealthSummaryWindow = 25;
+// Per-hook retention (fix wave F155): age-only pruning (boot + 12h timer) let a
+// chatty hook grow the table without bound, and the summary query ranks the
+// whole table synchronously on every 15s list poll. Trim on insert so the
+// table stays ≤ kMaxRequestsPerHook rows per hook; the age prune still runs.
+const kMaxRequestsPerHook = 500;
 
 const ensureDb = () => {
   if (!db) throw new Error("Webhooks DB not initialized");
@@ -139,6 +144,18 @@ const insertRequest = ({
       Number.isFinite(Number(gatewayStatus)) ? Number(gatewayStatus) : null,
     $gateway_body: gatewayBody || "",
   });
+  database
+    .prepare(`
+      DELETE FROM webhook_requests
+      WHERE hook_name = $hook_name
+        AND id NOT IN (
+          SELECT id FROM webhook_requests
+          WHERE hook_name = $hook_name
+          ORDER BY created_at DESC, id DESC
+          LIMIT $keep
+        )
+    `)
+    .run({ $hook_name: hookName, $keep: kMaxRequestsPerHook });
   return Number(info.lastInsertRowid || 0);
 };
 
@@ -427,6 +444,7 @@ const pruneOldEntries = (days = 30) => {
 };
 
 module.exports = {
+  kMaxRequestsPerHook,
   initWebhooksDb,
   closeWebhooksDb,
   insertRequest,

--- a/lib/server/routes/google.js
+++ b/lib/server/routes/google.js
@@ -704,9 +704,12 @@ const registerGoogleRoutes = ({
     }
     const client = account?.client || requestedClient || kDefaultGoogleClient;
     const email = account?.email || String(req.query.email || "").trim();
-    const services = (
+    // String() first (fix wave F209): a repeated/bracketed `services` query
+    // key arrives as an array/object, and `.split` threw a 500 before the
+    // try block's setup-page error redirect could run.
+    const services = String(
       req.query.services ||
-      (account?.services || kDefaultGoogleScopes).join(",")
+        (account?.services || kDefaultGoogleScopes).join(","),
     )
       .split(",")
       .map((scope) => String(scope || "").trim())

--- a/lib/server/routes/models.js
+++ b/lib/server/routes/models.js
@@ -355,11 +355,40 @@ const registerModelRoutes = ({
     }
     if (
       configuredModels !== undefined &&
-      (typeof configuredModels !== "object" || configuredModels === null)
+      (typeof configuredModels !== "object" || configuredModels === null || Array.isArray(configuredModels))
     ) {
       return res
         .status(400)
         .json({ ok: false, error: "Invalid configuredModels" });
+    }
+    // Validate EVERYTHING before the first write (fix wave F078/F212): a null
+    // profile entry used to 500 after setModelConfig had already rewritten
+    // openclaw.json (partial apply, catalog cache not marked stale), and an
+    // array smuggled through the object guard for authOrder.
+    if (authOrder !== undefined && (typeof authOrder !== "object" || authOrder === null || Array.isArray(authOrder))) {
+      return res.status(400).json({ ok: false, error: "Invalid authOrder" });
+    }
+    if (profiles !== undefined && !Array.isArray(profiles)) {
+      return res.status(400).json({ ok: false, error: "profiles must be an array" });
+    }
+    if (Array.isArray(profiles)) {
+      // Incomplete rows (blank id/type/provider) keep their long-standing
+      // contract: skipped, never saved. Shape and type violations are 400s.
+      const kValidProfileTypes = new Set(["api_key", "token", "oauth"]);
+      for (const [index, entry] of profiles.entries()) {
+        if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+          return res.status(400).json({ ok: false, error: `profiles[${index}] must be an object` });
+        }
+        if (entry.id !== undefined && entry.id !== null && typeof entry.id !== "string") {
+          return res.status(400).json({ ok: false, error: `profiles[${index}].id must be a string` });
+        }
+        if (entry.type && !kValidProfileTypes.has(entry.type)) {
+          return res.status(400).json({ ok: false, error: `profiles[${index}].type must be api_key, token, or oauth` });
+        }
+        if (entry.provider !== undefined && entry.provider !== null && typeof entry.provider !== "string") {
+          return res.status(400).json({ ok: false, error: `profiles[${index}].provider must be a string` });
+        }
+      }
     }
     try {
       // A held barrier is refused BEFORE any mutation; and the quiet-gated

--- a/lib/server/routes/team.js
+++ b/lib/server/routes/team.js
@@ -338,6 +338,15 @@ const registerTeamRoutes = ({
         .status(400)
         .json({ ok: false, error: "role must be admin or member" });
     }
+    // The manifest declares `disabled` boolean; any truthy value (the string
+    // "false" included) used to disable the member and rotate their secret
+    // (fix wave F210).
+    if (disabled !== undefined && typeof disabled !== "boolean") {
+      return res.status(400).json({ ok: false, error: "disabled must be a boolean" });
+    }
+    if (displayName !== undefined && displayName !== null && typeof displayName !== "string") {
+      return res.status(400).json({ ok: false, error: "displayName must be a string" });
+    }
     let member;
     try {
       member = membersStore.updateMember({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.80",
+  "version": "0.9.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alphaclaw",
-      "version": "0.9.80",
+      "version": "0.9.81",
       "license": "MIT",
       "dependencies": {
         "compression": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.80",
+  "version": "0.9.81",
   "publishConfig": {
     "access": "public"
   },

--- a/tests/server/autotune.test.js
+++ b/tests/server/autotune.test.js
@@ -850,4 +850,63 @@ describe("server/autotune", () => {
       restartTarget: "gateway",
     });
   });
+
+  it("the disable/kill-switch revert recovers a crash-window stale intent like the enable path (F082)", async () => {
+    const { openclawDir, managedDir } = makeTempDirs();
+    setLiveProfile({ memMb: 2048, cores: 1 });
+    resetAutotuneForTests({ managedDir });
+    // Crash window: intent persisted, openclaw.json written (adopted from
+    // absent), confirm never landed — then the operator disables autotune
+    // before another enable boot could confirm it.
+    fs.writeFileSync(
+      path.join(managedDir, "autotune-ledger.json"),
+      JSON.stringify({
+        ownedKeys: {
+          "agents.defaults.maxConcurrent": { intent: { value: 8, at: 1 } },
+        },
+      }),
+    );
+    const { store, fn } = makeConfigStore({
+      agents: { defaults: { maxConcurrent: 8 } },
+    });
+    await applyResourceAutotune({
+      deps: {
+        openclawDir,
+        updateOpenclawConfigFn: fn,
+        env: { ALPHACLAW_AUTOTUNE_DISABLED: "1" },
+      },
+    });
+    // The autotune-written value is reverted (deleted: adopted from absent)…
+    expect(store.config.agents.defaults.maxConcurrent).toBeUndefined();
+    // …and the provenance is cleared only because the revert actually ran.
+    const persisted = JSON.parse(
+      fs.readFileSync(path.join(managedDir, "autotune-ledger.json"), "utf8"),
+    );
+    expect(persisted.ownedKeys["agents.defaults.maxConcurrent"]).toBeUndefined();
+  });
+
+  it("a stale intent whose value does NOT match the config is not attributable on revert (operator wins)", async () => {
+    const { openclawDir, managedDir } = makeTempDirs();
+    setLiveProfile({ memMb: 2048, cores: 1 });
+    resetAutotuneForTests({ managedDir });
+    fs.writeFileSync(
+      path.join(managedDir, "autotune-ledger.json"),
+      JSON.stringify({
+        ownedKeys: {
+          "agents.defaults.maxConcurrent": { intent: { value: 8, at: 1 } },
+        },
+      }),
+    );
+    const { store, fn } = makeConfigStore({
+      agents: { defaults: { maxConcurrent: 96 } },
+    });
+    await applyResourceAutotune({
+      deps: {
+        openclawDir,
+        updateOpenclawConfigFn: fn,
+        env: { ALPHACLAW_AUTOTUNE_DISABLED: "1" },
+      },
+    });
+    expect(store.config.agents.defaults.maxConcurrent).toBe(96);
+  });
 });

--- a/tests/server/cost-utils.test.js
+++ b/tests/server/cost-utils.test.js
@@ -317,4 +317,22 @@ describe("server/cost-utils openclaw dist pricing scraper", () => {
 
     expect(pricingMap.size).toBe(0);
   });
+
+  it("bills cache-read tokens at 10% of the input rate when a static entry omits cacheRead (F083)", () => {
+    patchOpenclawResolution(null);
+    const costUtils = loadFreshCostUtils();
+    // claude-haiku-4-6 is a static entry with input/output only.
+    const breakdown = costUtils.deriveCostBreakdown({
+      provider: "anthropic",
+      model: "claude-haiku-4-6",
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 1_000_000,
+      cacheWriteTokens: 0,
+    });
+    expect(breakdown.pricingFound).toBe(true);
+    expect(breakdown.cacheReadCost).toBeGreaterThan(0);
+    expect(breakdown.cacheReadCost).toBeCloseTo(0.8 * 0.1, 8);
+    expect(breakdown.totalCost).toBeCloseTo(0.08, 8);
+  });
 });

--- a/tests/server/routes-models-coverage.test.js
+++ b/tests/server/routes-models-coverage.test.js
@@ -509,6 +509,62 @@ describe("server/routes/models coverage", () => {
     expect(deleteRes.statusCode).toBe(400);
     expect(deleteRes.body).toEqual({ ok: false, error: "Missing profileId" });
   });
+
+  describe("PUT /api/models/config validates the whole payload before any write (F078, F212)", () => {
+    it("rejects arrays for configuredModels and authOrder with 400 and writes nothing", async () => {
+      const deps = createModelDeps();
+      const app = createApp(deps);
+      const arrays = await request(app)
+        .put("/api/models/config")
+        .send({ configuredModels: ["openai/gpt-5.6"] });
+      expect(arrays.status).toBe(400);
+      expect(arrays.body.error).toBe("Invalid configuredModels");
+      const order = await request(app)
+        .put("/api/models/config")
+        .send({ authOrder: [["openai:default"]] });
+      expect(order.status).toBe(400);
+      expect(order.body.error).toBe("Invalid authOrder");
+      expect(deps.authProfiles.setModelConfig).not.toHaveBeenCalled();
+      expect(deps.authProfiles.upsertProfile).not.toHaveBeenCalled();
+    });
+
+    it("a null or malformed profile entry is a 400 naming the index — never a 500 after the config was written", async () => {
+      const deps = createModelDeps();
+      const app = createApp(deps);
+      const nullEntry = await request(app)
+        .put("/api/models/config")
+        .send({ primary: "openai/gpt-5.6", profiles: [null] });
+      expect(nullEntry.status).toBe(400);
+      expect(nullEntry.body.error).toBe("profiles[0] must be an object");
+
+      const badType = await request(app)
+        .put("/api/models/config")
+        .send({ profiles: [{ id: "openai:default", type: "password", provider: "openai", key: "sk" }] });
+      expect(badType.status).toBe(400);
+      expect(badType.body.error).toBe("profiles[0].type must be api_key, token, or oauth");
+
+      const badProvider = await request(app)
+        .put("/api/models/config")
+        .send({ profiles: [{ id: "openai:default", type: "api_key", provider: ["openai"], key: "sk" }] });
+      expect(badProvider.status).toBe(400);
+      expect(badProvider.body.error).toBe("profiles[0].provider must be a string");
+      const badId = await request(app)
+        .put("/api/models/config")
+        .send({ profiles: [{ id: { nested: true }, type: "api_key", provider: "openai", key: "sk" }] });
+      expect(badId.status).toBe(400);
+      expect(badId.body.error).toBe("profiles[0].id must be a string");
+
+      const notArray = await request(app)
+        .put("/api/models/config")
+        .send({ profiles: { id: "x" } });
+      expect(notArray.status).toBe(400);
+      expect(notArray.body.error).toBe("profiles must be an array");
+
+      // The model config was never written on any of the rejected requests.
+      expect(deps.authProfiles.setModelConfig).not.toHaveBeenCalled();
+      expect(deps.authProfiles.upsertProfile).not.toHaveBeenCalled();
+    });
+  });
 });
 
 // Fix wave F074: agentId reaches path.join in auth-profiles (agents/<id>/…),

--- a/tests/server/routes-oauth-binding.test.js
+++ b/tests/server/routes-oauth-binding.test.js
@@ -398,6 +398,18 @@ describe("server/routes OAuth callback binding (E-C11 / PR #114 pattern)", () =>
     expect(calls.some((url) => url.includes("userinfo"))).toBe(true);
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
+
+  it("a repeated/bracketed `services` query key does not 500 the start route (F209)", async () => {
+    const { app, tmpDir } = buildGoogleApp();
+    // startFlow asserts the 302 redirect itself; before the fix `.split` threw
+    // on the array Express parses from `services[]=…` and the terminal handler
+    // answered 500.
+    const state = await startFlow(app, { query: "?services[]=gmail&services[]=calendar" });
+    expect(state).toMatch(/^[0-9a-f]{32}$/);
+    const nested = await request(app).get("/auth/google/start?services[a]=gmail");
+    expect(nested.status).toBe(302);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
 });
 
 describe("server/watchdog-terminal-ws admin gate (4.6)", () => {

--- a/tests/server/routes-team.test.js
+++ b/tests/server/routes-team.test.js
@@ -559,4 +559,38 @@ describe("server/routes/team (4.5)", () => {
     expect(failing.body.identityProbe.ok).toBe(false);
     expect(failing.body.identityProbe.error).toContain("rejected the credential");
   });
+
+  it("PATCH member rejects a non-boolean `disabled` (the string \"false\" used to disable the member) — F210", async () => {
+    const adminCookie = await legacyCookie();
+    await enableTeam(adminCookie);
+    const invite = await request(app)
+      .post("/api/team/invites")
+      .set("Cookie", adminCookie)
+      .send({});
+    const accept = await request(app).post("/api/auth/accept-invite").send({
+      token: invite.body.token,
+      email: "member@example.com",
+      password: "member password",
+    });
+    const memberCookie = cookieOf(accept);
+    const memberRow = membersStore.getMemberByEmail("member@example.com");
+
+    const res = await request(app)
+      .patch(`/api/team/members/${memberRow.id}`)
+      .set("Cookie", adminCookie)
+      .send({ disabled: "false" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("disabled must be a boolean");
+    // Nothing changed: the member's session still works.
+    expect(
+      (await request(app).get("/api/team").set("Cookie", memberCookie)).status,
+    ).toBe(200);
+
+    const badName = await request(app)
+      .patch(`/api/team/members/${memberRow.id}`)
+      .set("Cookie", adminCookie)
+      .send({ displayName: ["x"] });
+    expect(badName.status).toBe(400);
+    expect(badName.body.error).toBe("displayName must be a string");
+  });
 });

--- a/tests/server/usage-db.test.js
+++ b/tests/server/usage-db.test.js
@@ -478,6 +478,79 @@ describe("server/usage-db", () => {
     expect(usage.totals.runCount).toBe(2);
     expect(usage.totals.totalTokens).toBe(200_000);
   });
+
+  it("getSessionsList reads every selected session's events in ONE query and keeps per-event costing (fix wave F076)", () => {
+    const { database } = createUsageDbContext("usage-db-sessions-1n-");
+    const sessions = require("../../lib/server/db/usage/sessions");
+    const insertUsageEvent = database.prepare(`
+      INSERT INTO usage_events (
+        timestamp, session_id, session_key, run_id, provider, model,
+        input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, total_tokens
+      ) VALUES (
+        $timestamp, $session_id, $session_key, $run_id, $provider, $model,
+        $input_tokens, $output_tokens, $cache_read_tokens, $cache_write_tokens, $total_tokens
+      )
+    `);
+    const now = Date.now();
+    const events = [
+      { session_key: "s-a", session_id: "", model: "anthropic/claude-opus-4.7", input: 1000, output: 100, ts: now - 5000 },
+      { session_key: "s-a", session_id: "", model: "openai/gpt-5.6", input: 500, output: 50, ts: now - 4000 },
+      { session_key: "", session_id: "raw-b", model: "anthropic/claude-opus-4.7", input: 200, output: 20, ts: now - 3000 },
+      { session_key: "s-c", session_id: "raw-c", model: "openai/gpt-5.6", input: 300, output: 30, ts: now - 2000 },
+    ];
+    for (const event of events) {
+      insertUsageEvent.run({
+        $timestamp: event.ts,
+        $session_id: event.session_id,
+        $session_key: event.session_key,
+        $run_id: "run",
+        $provider: event.model.split("/")[0],
+        $model: event.model,
+        $input_tokens: event.input,
+        $output_tokens: event.output,
+        $cache_read_tokens: 0,
+        $cache_write_tokens: 0,
+        $total_tokens: event.input + event.output,
+      });
+    }
+
+    const prepareSpy = vi.spyOn(database, "prepare");
+    const list = sessions.getSessionsList({ database, limit: 10 });
+    // One aggregate query + one events query — never one per session row.
+    expect(prepareSpy).toHaveBeenCalledTimes(2);
+    prepareSpy.mockRestore();
+
+    expect(list.map((row) => row.sessionId)).toEqual(["s-c", "raw-b", "s-a"]);
+    const sessionA = list.find((row) => row.sessionId === "s-a");
+    expect(sessionA.turnCount).toBe(2);
+    expect(sessionA.totalTokens).toBe(1650);
+    expect(sessionA.dominantModel).toBe("anthropic/claude-opus-4.7");
+    const expectedCostA =
+      deriveCostBreakdown({ provider: "anthropic", model: "anthropic/claude-opus-4.7", inputTokens: 1000, outputTokens: 100 }).totalCost +
+      deriveCostBreakdown({ provider: "openai", model: "openai/gpt-5.6", inputTokens: 500, outputTokens: 50 }).totalCost;
+    expect(sessionA.totalCost).toBeCloseTo(expectedCostA, 10);
+    const sessionB = list.find((row) => row.sessionId === "raw-b");
+    expect(sessionB.rawSessionId).toBe("raw-b");
+    expect(sessionB.turnCount).toBe(1);
+  });
+
+  it("getSessionsList with no sessions issues a single query and returns []", () => {
+    const { database } = createUsageDbContext("usage-db-sessions-empty-");
+    const sessions = require("../../lib/server/db/usage/sessions");
+    const prepareSpy = vi.spyOn(database, "prepare");
+    expect(sessions.getSessionsList({ database, limit: 10 })).toEqual([]);
+    expect(prepareSpy).toHaveBeenCalledTimes(1);
+    prepareSpy.mockRestore();
+  });
+
+  it("the schema carries the session-ref expression index (fix wave F076)", () => {
+    const { database } = createUsageDbContext("usage-db-sessions-index-");
+    const indexes = database
+      .prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'usage_events'")
+      .all()
+      .map((row) => row.name);
+    expect(indexes).toContain("idx_usage_events_session_ref");
+  });
 });
 
 // withStaleOnBusy: reads that hit SQLITE_BUSY after the 250ms busy_timeout

--- a/tests/server/webhooks-db.test.js
+++ b/tests/server/webhooks-db.test.js
@@ -264,4 +264,52 @@ describe("server/webhooks-db", () => {
       expect.any(String),
     );
   });
+
+  it("keeps only the newest kMaxRequestsPerHook rows per hook on insert (fix wave F155)", () => {
+    const { insertRequest, getHookSummaries, kMaxRequestsPerHook } =
+      createWebhooksDbContext("webhooks-db-keepn-");
+    expect(kMaxRequestsPerHook).toBe(500);
+    const total = kMaxRequestsPerHook + 20;
+    for (let index = 0; index < total; index += 1) {
+      insertRequest({
+        hookName: "chatty",
+        method: "POST",
+        headers: {},
+        payload: `{"index":${index}}`,
+        payloadTruncated: false,
+        payloadSize: 12,
+        sourceIp: "127.0.0.1",
+        gatewayStatus: 200,
+        gatewayBody: "",
+      });
+    }
+    for (let index = 0; index < 3; index += 1) {
+      insertRequest({
+        hookName: "quiet",
+        method: "POST",
+        headers: {},
+        payload: `{"index":${index}}`,
+        payloadTruncated: false,
+        payloadSize: 12,
+        sourceIp: "127.0.0.1",
+        gatewayStatus: 200,
+        gatewayBody: "",
+      });
+    }
+    const summaries = getHookSummaries();
+    expect(summaries.find((item) => item.hookName === "chatty").totalCount).toBe(kMaxRequestsPerHook);
+    // Another hook's retention is independent.
+    expect(summaries.find((item) => item.hookName === "quiet").totalCount).toBe(3);
+    // The NEWEST rows survive.
+    const database = new DatabaseSync(currentDbPath, { readOnly: true });
+    const oldest = database
+      .prepare("SELECT MIN(payload) AS p FROM webhook_requests WHERE hook_name = 'chatty' AND payload LIKE '{\"index\":%'")
+      .get();
+    const kept = database
+      .prepare("SELECT payload FROM webhook_requests WHERE hook_name = 'chatty' ORDER BY id ASC LIMIT 1")
+      .get();
+    database.close();
+    expect(JSON.parse(kept.payload).index).toBe(20);
+    expect(oldest.p).toBeTruthy();
+  });
 });


### PR DESCRIPTION
Fix wave, PR 8c of the sequence (stacked on #68 → #67 → #66 → #65 → #63 → #62 → #61 → #60; merges into `kolkata-v4-pr8b`). Audit batch 22: server odds and ends. Version **0.9.81**.

## What changed

- **F076 (P2)** — `db/usage/sessions.js getSessionsList` re-prepared and ran an unindexable per-session events query for every row (1+N full scans, up to 200 per Usage tab open, growing with install age, blocking the event loop). One events read now serves every selected session; per-event costing is kept (tiered pricing depends on each event's token count). `schema.js` adds the expression index `idx_usage_events_session_ref` on `COALESCE(NULLIF(session_key,''), NULLIF(session_id,''))` — the predicate is spelled identically in `sessions.js` so SQLite can use it. Test asserts exactly 2 prepares per call and unchanged totals/costs.
- **F155** — `db/webhooks` inserts trim to the newest `kMaxRequestsPerHook` (500) rows per hook; the age prune (boot + 12h) still runs. Bounds the synchronous ranking query the 15s list poll runs.
- **F078 / F212** — `PUT /api/models/config` validates the whole payload before the first write: arrays no longer pass the `configuredModels`/`authOrder` object guards; `profiles` must be an array of objects with string `id`, `type ∈ {api_key, token, oauth}`, string `provider` — a violation is a 400 naming `profiles[i].field`, and nothing is written (before: a `null` entry 500ed after `setModelConfig` had already rewritten openclaw.json).
- **F082** — the autotune disable/kill-switch revert now recovers a crash-window stale intent exactly like the enable path (matching value ⇒ autotune-owned; `ownedFromAbsent` inferred when no prior confirmed write exists). Before it left autotune's own `maxConcurrent` in openclaw.json and deleted its provenance. A non-matching stale intent still leaves the operator's value alone.
- **F083** — `cost-utils`: static fallback entries without `cacheRead` billed cache reads at $0. They now fall back to 10% of the input rate (the provider-documented ratio for Anthropic and OpenAI GPT-5 "cached input"), matching the existing `cacheWrite → input` fallback.
- **F209** — `/auth/google/start` coerces `services` with `String()` before `.split` (a repeated/bracketed query key arrived as an array and threw a 500 before the setup-page error redirect).
- **F210** — `PATCH /api/team/members/:id`: `disabled` must be a real boolean (the string `"false"` used to disable the member and rotate their secret with a 200); `displayName` must be a string.

## Deferred (overlap with open PR #64 `louisville`, which edits `routes/system.js`)
F077 (`/api/agent/message` under `clawCmd`'s 15s default), F081 (`fetchGitHubRelease` never settles on a mid-body close; unbounded body), F208 (`PUT /api/env` 500 on a `null` element after taking the lifecycle lock). They follow once #64 lands.

## Overlap / reconciliation
No open PR touches the files changed here. `origin/main` is still v0.9.72; renumber in the final pre-merge commit if that changes.

## Supersedes recent work
None of the rewritten code is younger than 7 days (usage sessions, webhooks DB, models routes, autotune revert, cost-utils predate 2026-08-28); this PR extends, it does not remove.

## Verification
- `npm test` (Node 22, sandbox `OPENCLAW_*` env unset): see the final run noted in the PR conversation.
- Extended: `webhooks-db` (+1), `usage-db` (+3), `routes-models-coverage` (+2), `autotune` (+2), `cost-utils` (+1), `routes-oauth-binding` (+1), `routes-team` (+1).
- No `lib/public/js` change. Container tier not runnable here (no Docker); CI's Container E2E runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/897cdaac-c48b-433c-8ab5-3f1ca0b5fe30)
