### PR TITLE
v0.9.82 fix: Doctor — skills-bloat key split, lean runs poll, bounded prompt history, worker cooldown, stable env signature, evidence whitelist (fix wave PR 9a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,46 @@ All notable changes to AlphaClaw are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow this repository's `package.json` release counter.
 
+## [0.9.82] - 2026-09-04
+
+Fix wave, PR 9a — Doctor.
+
+### Fixed
+- **Dismissing the skills-bloat nudge hid the escalation** (audit F109). The
+  P2 near-limit warning and the P1 over-limit card shared one `sourceKey`, so
+  a dismissed nudge permanently suppressed the later escalation. The keys are
+  now `det:skills-bloat:near` / `det:skills-bloat:over` (same doctrine as the
+  memory-budget cards). A previously dismissed nudge resurfaces once under its
+  new key.
+- **`GET /api/doctor/runs` parsed multi-MB manifests on every poll** (F110).
+  The Doctor tab polls it every 15s (2s during a run) and reads only `id`,
+  `status`, and counts; the endpoint now serves the lean run summaries
+  (`/api/doctor/runs/:id` keeps the full model with `workspaceManifest` and
+  `rawResult`).
+- **Doctor prompt history grew without bound** (F111). Every historical
+  dismissed/fixed card row (cloned by each reuse run, never pruned) was
+  rendered into the LLM prompt with no dedupe or cap, and the `--params` exec
+  argument had no byte budget unlike the fix dispatcher. History is deduped by
+  status+title+category and capped at 40 per status; the run refuses with a
+  clear error only if the prompt still exceeds the argument budget with history
+  dropped.
+- **Fingerprint worker stayed disabled until restart** (F112). Three
+  consecutive request timeouts (an environmental stall, not a worker defect)
+  tripped the respawn cap for the rest of the process, blinding the scheduled
+  drift trigger. The budget re-opens after a 10-minute cooldown.
+- **Spurious scheduled scans on restart** (F113). The env signature hashed the
+  model catalog's `source` label (`openclaw` vs `cache`), which flips on every
+  restart and Models-tab refresh; only the model rows are hashed now.
+- **Forged evidence snippets** (F114). Evidence items passed arbitrary keys
+  through, and a pre-existing `snippet` was never cleared, so an LLM- or
+  import-supplied excerpt rendered as a server-read "snapshot" block. Evidence
+  is whitelisted to `type/text/path/startLine/endLine`, and `snippet` is always
+  set by the server or absent.
+
+### Notes
+- Tests: extended `doctor-deterministic-checks`, `routes-doctor`,
+  `doctor-service`, `doctor-normalize`, `fix-batch-regressions`.
+
 ## [0.9.81] - 2026-09-04
 
 Fix wave, PR 8c — server odds and ends.

--- a/lib/server/doctor/deterministic-checks.js
+++ b/lib/server/doctor/deterministic-checks.js
@@ -654,8 +654,12 @@ const buildDeterministicCards = ({
       const longest = [...skills]
         .sort((a, b) => b.description.length - a.description.length)
         .slice(0, 3);
+      // Distinct keys for the P2 nudge and the P1 escalation (fix wave F109):
+      // one key meant dismissing the near-limit warning permanently hid the
+      // over-limit card — same doctrine as det:memory-budget:near/over. A
+      // previously dismissed nudge resurfaces once under its new key.
       addCard({
-        sourceKey: "det:skills-bloat",
+        sourceKey: overCount || overChars ? "det:skills-bloat:over" : "det:skills-bloat:near",
         priority: overCount || overChars ? "P1" : "P2",
         category: "skills",
         title:

--- a/lib/server/doctor/normalize.js
+++ b/lib/server/doctor/normalize.js
@@ -89,6 +89,8 @@ const normalizeCardStatus = (value) => {
   return kDoctorCardStatus.open;
 };
 
+const kEvidenceItemKeys = Object.freeze(["type", "text", "path", "startLine", "endLine"]);
+
 const normalizeEvidenceItem = (item) => {
   if (item == null) return null;
   if (typeof item === "string") {
@@ -96,7 +98,16 @@ const normalizeEvidenceItem = (item) => {
     return text ? { type: "text", text } : null;
   }
   if (typeof item === "object") {
-    const entry = { ...item };
+    // Whitelist (fix wave F114): evidence arrives from the LLM and from
+    // imports. `snippet` is SERVER-read file content (captureEvidenceSnippets)
+    // rendered as a trusted "snapshot" block — a forged one must never pass
+    // through, and unknown keys have no renderer.
+    const entry = {};
+    for (const key of kEvidenceItemKeys) {
+      if (item[key] !== undefined) entry[key] = item[key];
+    }
+    if (entry.type !== undefined) entry.type = toTrimmedString(entry.type);
+    if (entry.text !== undefined) entry.text = toTrimmedString(entry.text);
     if (entry.type === "path" && entry.path) {
       entry.path = toTrimmedString(entry.path);
       if (Number.isFinite(entry.startLine) && entry.startLine > 0) {
@@ -109,6 +120,10 @@ const normalizeEvidenceItem = (item) => {
       } else {
         delete entry.endLine;
       }
+    } else {
+      delete entry.path;
+      delete entry.startLine;
+      delete entry.endLine;
     }
     return entry;
   }

--- a/lib/server/doctor/service.js
+++ b/lib/server/doctor/service.js
@@ -79,6 +79,27 @@ const kDoctorFixDispatchTimeoutMs = 30000;
 // expansion is already counted).
 const kDoctorFixParamsMaxBytes = 120 * 1000;
 
+// Historical (dismissed/fixed) cards fed to the LLM prompt: reuse runs clone
+// card rows on every run, so the same finding appears many times and the list
+// grows without bound (fix wave F111). Dedupe by status+title+category and cap
+// per status; the newest rows win (listDoctorCards is newest-first).
+const kDoctorHistoryMaxPerStatus = 40;
+const dedupeResolvedCards = (cards = []) => {
+  const seen = new Set();
+  const perStatus = new Map();
+  const out = [];
+  for (const card of cards) {
+    const key = `${card.status}|${card.title}|${card.category}`;
+    if (seen.has(key)) continue;
+    const count = perStatus.get(card.status) || 0;
+    if (count >= kDoctorHistoryMaxPerStatus) continue;
+    seen.add(key);
+    perStatus.set(card.status, count + 1);
+    out.push(card);
+  }
+  return out;
+};
+
 const buildDoctorFixCompletionInstructions = ({
   cardId,
   runId,
@@ -245,7 +266,11 @@ const captureEvidenceSnippets = (cards, rootDir, redact = (text) => text) => {
   for (const card of cards) {
     if (!Array.isArray(card.evidence)) continue;
     for (const item of card.evidence) {
-      if (!item || item.type !== "path" || !item.path || !item.startLine) continue;
+      if (!item || typeof item !== "object") continue;
+      // Only the server sets `snippet` (F114): drop anything that arrived with
+      // the card, then read the cited window fresh.
+      delete item.snippet;
+      if (item.type !== "path" || !item.path || !item.startLine) continue;
       const snippet = readFileSnippet(rootDir, item.path, item.startLine, item.endLine, redact);
       if (snippet) item.snippet = snippet;
     }
@@ -840,7 +865,8 @@ const createDoctorService = ({
   };
 
   // Slim by contract: status consumers never receive workspaceManifest or
-  // rawResult; /api/doctor/runs keeps serving the full run models.
+  // rawResult; /api/doctor/runs serves lean summaries too (fix wave F110) —
+  // the full run model (manifest + rawResult) is /api/doctor/runs/:id only.
   const toSlimLatestRun = (run) =>
     run
       ? {
@@ -934,34 +960,52 @@ const createDoctorService = ({
   const executeDoctorRun = async (runId) => {
     try {
       const allCards = listDoctorCards();
-      const resolvedCards = allCards
-        .filter((card) => card.status === "dismissed" || card.status === "fixed")
-        .map((card) => ({
-          status: card.status,
-          title: card.title || "",
-          category: card.category || "",
-        }));
-      const prompt = buildDoctorPrompt({
-        workspaceRoot,
-        managedRoot,
-        protectedPaths,
-        lockedPaths,
-        resolvedCards,
-        promptVersion: kDoctorPromptVersion,
-        profile: getActiveProfile(),
-        bootstrapContext: bootstrapAnalyzer.analyze(),
-        installedVersion: safeInstalledVersion(),
-        releaseChannel: safeReleaseChannel(),
-      });
+      const resolvedCards = dedupeResolvedCards(
+        allCards
+          .filter((card) => card.status === "dismissed" || card.status === "fixed")
+          .map((card) => ({
+            status: card.status,
+            title: card.title || "",
+            category: card.category || "",
+          })),
+      );
+      const buildPrompt = (history) =>
+        buildDoctorPrompt({
+          workspaceRoot,
+          managedRoot,
+          protectedPaths,
+          lockedPaths,
+          resolvedCards: history,
+          promptVersion: kDoctorPromptVersion,
+          profile: getActiveProfile(),
+          bootstrapContext: bootstrapAnalyzer.analyze(),
+          installedVersion: safeInstalledVersion(),
+          releaseChannel: safeReleaseChannel(),
+        });
+      let prompt = buildPrompt(resolvedCards);
       const gatewayTimeoutMs = kDoctorRunTimeoutMs + 30000;
-      const gatewayParams = {
+      const buildGatewayParams = (message) => ({
         agentId: "main",
         idempotencyKey: buildDoctorIdempotencyKey(runId),
-        message: prompt,
+        message,
         sessionKey: buildDoctorSessionKey(runId),
         thinking: "medium",
         timeout: Math.round(kDoctorRunTimeoutMs / 1000),
-      };
+      });
+      // Same one-exec-argument budget requestCardFix enforces (fix wave F111):
+      // the history section is the only unbounded input, so drop it first and
+      // only then refuse — a prompt that cannot fit even without history is a
+      // configuration problem worth a clear error, not an opaque E2BIG.
+      let gatewayParams = buildGatewayParams(prompt);
+      if (Buffer.byteLength(shellEscapeArg(JSON.stringify(gatewayParams)), "utf8") > kDoctorFixParamsMaxBytes) {
+        prompt = buildPrompt([]);
+        gatewayParams = buildGatewayParams(prompt);
+        if (Buffer.byteLength(shellEscapeArg(JSON.stringify(gatewayParams)), "utf8") > kDoctorFixParamsMaxBytes) {
+          throw new Error(
+            `Doctor prompt exceeds the gateway argument budget (${kDoctorFixParamsMaxBytes} bytes) even without history — shrink protected/locked path lists or the workspace context`,
+          );
+        }
+      }
       // The upstream-doctor bridge runs in parallel with the (much slower)
       // LLM call. Bridge failure is fail-soft; LLM failure fails the run.
       const [llmSettled, bridgeSettled] = await Promise.allSettled([
@@ -1230,8 +1274,10 @@ const createDoctorService = ({
       modelCatalog: (() => {
         try {
           const catalog = safeCatalog();
+          // `source` ("openclaw" vs "cache") flips on every restart and Models
+          // tab refresh without any model changing — hashing it fired spurious
+          // scheduled scans (fix wave F113). Only the model rows matter.
           return {
-            source: catalog.source,
             models: catalog.models.map((row) => [
               row?.key ?? null,
               row?.contextWindow ?? null,
@@ -1995,6 +2041,10 @@ const createDoctorService = ({
     // Exported (route-facing) run readers scrub legacy frozen-elapsed reuse
     // summaries on the way out; internal callers keep the raw injected fns.
     listDoctorRuns: (options) => listDoctorRuns(options).map(scrubRunSummary),
+    // Lean per-poll listing (F110): no workspace manifest / rawResult parse
+    // for fields the Doctor tab never reads.
+    listDoctorRunSummaries: (options) =>
+      listDoctorRunSummariesFn(options).map(scrubRunSummary),
     listDoctorCards,
     getDoctorRun: (id) => scrubRunSummary(getDoctorRun(id)),
     getDoctorCardsByRunId,
@@ -2011,6 +2061,8 @@ const createDoctorService = ({
 
 module.exports = {
   buildDoctorFixCompletionInstructions,
+  dedupeResolvedCards,
+  kDoctorHistoryMaxPerStatus,
   buildDoctorIdempotencyKey,
   buildDoctorSessionKey,
   createDoctorService,

--- a/lib/server/doctor/workspace-fingerprint.js
+++ b/lib/server/doctor/workspace-fingerprint.js
@@ -420,6 +420,11 @@ const { getProfilePathChangeWeight, kStableProfile } = require("./context-profil
 const kFingerprintWorkerScriptPath = path.join(__dirname, "fingerprint-worker.js");
 const kSnapshotWorkerRequestTimeoutMs = 10 * 60 * 1000;
 const kMaxSnapshotWorkerRespawns = 3;
+// After the cap trips, the budget re-opens once this long has passed since the
+// last failure (fix wave F112): three timeouts from an environmental stall
+// (backup barrier, disk contention) used to blind the drift trigger until an
+// AlphaClaw restart. Explicit runs always had the sync fallback.
+const kSnapshotWorkerRespawnCooldownMs = 10 * 60 * 1000;
 
 // Parent-side wrapper around one persistent fingerprint worker thread. The
 // worker is spawned lazily, reused across jobs, and recycled on error/exit so
@@ -433,12 +438,19 @@ const createWorkspaceSnapshotWorkerClient = ({
   workerScriptPath = kFingerprintWorkerScriptPath,
   createWorker = (scriptPath) => new Worker(scriptPath),
   requestTimeoutMs = kSnapshotWorkerRequestTimeoutMs,
+  respawnCooldownMs = kSnapshotWorkerRespawnCooldownMs,
+  now = Date.now,
 } = {}) => {
   let worker = null;
   let nextJobId = 1;
   let respawnCount = 0;
+  let lastFailureAt = 0;
   let terminated = false;
   const pendingJobs = new Map();
+  const noteFailure = () => {
+    respawnCount += 1;
+    lastFailureAt = now();
+  };
 
   const failPendingJobs = (error) => {
     const jobs = [...pendingJobs.values()];
@@ -458,7 +470,11 @@ const createWorkspaceSnapshotWorkerClient = ({
   const ensureWorker = () => {
     if (worker) return worker;
     if (respawnCount >= kMaxSnapshotWorkerRespawns) {
-      throw new Error("Workspace snapshot worker unavailable (respawn cap reached)");
+      if (now() - lastFailureAt < respawnCooldownMs) {
+        throw new Error("Workspace snapshot worker unavailable (respawn cap reached)");
+      }
+      // Cooldown elapsed: one more budget of attempts (F112).
+      respawnCount = 0;
     }
     const spawned = createWorker(workerScriptPath);
     worker = spawned;
@@ -486,14 +502,14 @@ const createWorkspaceSnapshotWorkerClient = ({
     spawned.on("error", (error) => {
       if (worker !== spawned) return;
       worker = null;
-      respawnCount += 1;
+      noteFailure();
       spawned.terminate?.()?.catch?.(() => {});
       failPendingJobs(error instanceof Error ? error : new Error(String(error)));
     });
     spawned.on("exit", () => {
       if (worker !== spawned) return;
       worker = null;
-      respawnCount += 1;
+      noteFailure();
       failPendingJobs(new Error("Workspace snapshot worker exited"));
     });
     // The worker must never keep the server process alive on its own.
@@ -529,7 +545,7 @@ const createWorkspaceSnapshotWorkerClient = ({
         // respawns, counted against the cap) and fail every pending job —
         // they shared the terminated worker and would otherwise strand.
         pendingJobs.delete(jobId);
-        respawnCount += 1;
+        noteFailure();
         disposeWorker();
         failPendingJobs(new Error("Workspace snapshot worker timed out"));
         reject(new Error("Workspace snapshot worker timed out"));
@@ -648,6 +664,8 @@ const calculateWorkspaceDelta = ({
 };
 
 module.exports = {
+  kSnapshotWorkerRespawnCooldownMs,
+  kMaxSnapshotWorkerRespawns,
   calculateWorkspaceDelta,
   computeWorkspaceFingerprintFromManifest,
   computeWorkspaceSnapshot,

--- a/lib/server/routes/doctor.js
+++ b/lib/server/routes/doctor.js
@@ -189,7 +189,11 @@ const registerDoctorRoutes = ({
   app.get("/api/doctor/runs", requireAuth, (req, res) => {
     try {
       const limit = Number.parseInt(String(req.query.limit || kDoctorDefaultRunsLimit), 10);
-      const runs = doctorService.listDoctorRuns({ limit });
+      // Lean summaries (fix wave F110): this endpoint is polled every 15s (2s
+      // during a run) and no consumer reads workspaceManifest/rawResult —
+      // /api/doctor/runs/:id keeps the full model.
+      const listRuns = doctorService.listDoctorRunSummaries || doctorService.listDoctorRuns;
+      const runs = listRuns({ limit });
       res.json({ ok: true, runs });
     } catch (error) {
       res.status(500).json({ ok: false, error: error.message });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.81",
+  "version": "0.9.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alphaclaw",
-      "version": "0.9.81",
+      "version": "0.9.82",
       "license": "MIT",
       "dependencies": {
         "compression": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.81",
+  "version": "0.9.82",
   "publishConfig": {
     "access": "public"
   },

--- a/tests/server/doctor-deterministic-checks.test.js
+++ b/tests/server/doctor-deterministic-checks.test.js
@@ -45,6 +45,14 @@ describe("server/doctor/deterministic-checks", () => {
       ...overrides,
     });
 
+  // F109 split the key into :near (P2) / :over (P1) so a dismissed nudge never
+
+  // hides the escalation; tests that only care "did the bloat card fire" use this.
+
+  const findSkillsBloatCard = (cards) =>
+
+    cards.find((card) => String(card.sourceKey).startsWith("det:skills-bloat:"));
+
   const findCard = (cards, sourceKey) =>
     cards.find((card) => card.sourceKey === sourceKey);
 
@@ -437,7 +445,7 @@ describe("server/doctor/deterministic-checks", () => {
       );
     }
     const overCards = build({});
-    expect(findCard(overCards, "det:skills-bloat")).toMatchObject({
+    expect(findSkillsBloatCard(overCards)).toMatchObject({
       priority: "P1",
       category: "skills",
     });
@@ -451,13 +459,13 @@ describe("server/doctor/deterministic-checks", () => {
         `---\nname: small-${index}\ndescription: tiny\n---\nbody`,
       );
     }
-    expect(findCard(build({}), "det:skills-bloat")).toBeUndefined();
+    expect(findCard(build({}), "det:skills-bloat:over")).toBeUndefined();
 
     // Custom lower limits via config overrides push the small set over.
     expect(
       findCard(
         build({ skillsLimits: { maxSkillsInPrompt: 3 } }),
-        "det:skills-bloat",
+        "det:skills-bloat:over",
       ),
     ).toMatchObject({ priority: "P1" });
   });
@@ -487,7 +495,7 @@ describe("server/doctor/deterministic-checks", () => {
     // marker-only parse estimated 118 chars and emitted nothing.
     const card = findCard(
       build({ skillsLimits: { maxSkillsPromptChars: 3000 } }),
-      "det:skills-bloat",
+      "det:skills-bloat:over",
     );
     expect(card).toMatchObject({ priority: "P1", category: "skills" });
     expect(card.evidence[0].text).toContain("skills/literal: description 3002 chars");
@@ -512,7 +520,7 @@ describe("server/doctor/deterministic-checks", () => {
     );
     const card = findCard(
       build({ skillsLimits: { maxSkillsPromptChars: 3000 } }),
-      "det:skills-bloat",
+      "det:skills-bloat:over",
     );
     // Exactly 3,001 chars (2 x 1,500 + the joining newline): the name: line
     // is NOT swallowed into the description.
@@ -527,7 +535,7 @@ describe("server/doctor/deterministic-checks", () => {
       "skills/a/b/c/d/e/f/g/SKILL.md",
       "---\nname: deep\ndescription: x\n---\n",
     );
-    expect(findCard(build({}), "det:skills-bloat")).toBeUndefined();
+    expect(findCard(build({}), "det:skills-bloat:over")).toBeUndefined();
   });
 
   it("bounds the skills scan by visited dirents on a wide tree and stays an estimate", () => {
@@ -545,7 +553,7 @@ describe("server/doctor/deterministic-checks", () => {
       skillsLimits: { maxSkillsInPrompt: 2 },
       skillsScanMaxVisitedDirents: 50,
     });
-    const card = findCard(cards, "det:skills-bloat");
+    const card = findSkillsBloatCard(cards);
     expect(card).toMatchObject({ priority: "P1" });
     expect(card.summary).toContain("Scan hit its safety cap; the real count is higher.");
     // The budget stopped the walk well before all 300 skills were counted.
@@ -555,7 +563,7 @@ describe("server/doctor/deterministic-checks", () => {
     // Production default budget: the same tree scans completely — no
     // truncation note, full count.
     const fullCards = build({ skillsLimits: { maxSkillsInPrompt: 2 } });
-    const fullCard = findCard(fullCards, "det:skills-bloat");
+    const fullCard = findSkillsBloatCard(fullCards);
     expect(fullCard.summary).toContain("~300 workspace skills");
     expect(fullCard.summary).not.toContain("Scan hit its safety cap");
   });
@@ -729,6 +737,35 @@ describe("server/doctor/deterministic-checks", () => {
       expect(card.sourceKey.startsWith("det:")).toBe(true);
       expect(card.fixPrompt.length).toBeGreaterThan(0);
     }
+  });
+
+  it("uses distinct sourceKeys for the P2 near-limit nudge and the P1 over-limit escalation (F109)", () => {
+    // 10 skills x (97 overhead + 1500 desc + name/location) ≈ 16.1k: past the
+    // 85% band of the 18k default, below the limit → near.
+    for (let index = 0; index < 10; index += 1) {
+      write(
+        workspaceRoot,
+        `skills/near-${index}/SKILL.md`,
+        `---\nname: near-${index}\ndescription: ${"d".repeat(1500)}\n---\nbody`,
+      );
+    }
+    const nearCards = build({});
+    expect(findCard(nearCards, "det:skills-bloat:near")).toMatchObject({ priority: "P2" });
+    expect(findCard(nearCards, "det:skills-bloat:over")).toBeUndefined();
+    expect(findCard(nearCards, "det:skills-bloat")).toBeUndefined();
+
+    // Push over the limit: the escalation carries the OTHER key, so a
+    // dismissed nudge can never suppress it.
+    for (let index = 0; index < 4; index += 1) {
+      write(
+        workspaceRoot,
+        `skills/over-${index}/SKILL.md`,
+        `---\nname: over-${index}\ndescription: ${"d".repeat(1500)}\n---\nbody`,
+      );
+    }
+    const overCards = build({});
+    expect(findCard(overCards, "det:skills-bloat:over")).toMatchObject({ priority: "P1" });
+    expect(findCard(overCards, "det:skills-bloat:near")).toBeUndefined();
   });
 });
 

--- a/tests/server/doctor-normalize.test.js
+++ b/tests/server/doctor-normalize.test.js
@@ -231,4 +231,31 @@ describe("server/doctor-normalize", () => {
       "Focus on these paths if relevant: AGENTS.md.",
     );
   });
+
+  it("drops forged snippets and unknown evidence keys (fix wave F114)", () => {
+    const card = normalizeDoctorCard(
+      {
+        title: "Forged evidence",
+        evidence: [
+          {
+            type: "path",
+            path: "AGENTS.md",
+            startLine: 1,
+            endLine: 2,
+            // Server-only field: a supplied value would render as a trusted
+            // "snapshot" block of file content the server never read.
+            snippet: { lines: ["rm -rf /"], startLine: 1, endLine: 1 },
+            extra: "ignored",
+          },
+          { type: "text", text: "  note  ", snippet: "forged", path: "not-for-text.md", startLine: 9 },
+        ],
+      },
+      0,
+    );
+    expect(card.evidence).toEqual([
+      { type: "path", path: "AGENTS.md", startLine: 1, endLine: 2 },
+      { type: "text", text: "note" },
+    ]);
+    expect(JSON.stringify(card.evidence)).not.toMatch(/snippet|forged|rm -rf|extra/);
+  });
 });

--- a/tests/server/doctor-service.test.js
+++ b/tests/server/doctor-service.test.js
@@ -4341,3 +4341,44 @@ describe("server/doctor-service hardening transition log", () => {
     expect(hardeningWarnCalls(warnSpy)).toHaveLength(0);
   });
 });
+
+describe("doctor prompt history dedupe (fix wave F111)", () => {
+  const {
+    dedupeResolvedCards,
+    kDoctorHistoryMaxPerStatus,
+  } = require("../../lib/server/doctor/service");
+
+  it("collapses reuse-run clones to one line per status+title+category, newest first", () => {
+    const cards = [
+      { status: "dismissed", title: "Cleanup docs", category: "workspace" },
+      { status: "dismissed", title: "Cleanup docs", category: "workspace" },
+      { status: "fixed", title: "Cleanup docs", category: "workspace" },
+      { status: "dismissed", title: "Cleanup docs", category: "skills" },
+      { status: "dismissed", title: "Cleanup docs", category: "workspace" },
+    ];
+    expect(dedupeResolvedCards(cards)).toEqual([
+      { status: "dismissed", title: "Cleanup docs", category: "workspace" },
+      { status: "fixed", title: "Cleanup docs", category: "workspace" },
+      { status: "dismissed", title: "Cleanup docs", category: "skills" },
+    ]);
+  });
+
+  it("caps each status at kDoctorHistoryMaxPerStatus, keeping the earliest (newest) rows", () => {
+    const many = Array.from({ length: kDoctorHistoryMaxPerStatus + 15 }, (_, i) => ({
+      status: "dismissed",
+      title: `Finding ${i}`,
+      category: "workspace",
+    }));
+    const fixed = Array.from({ length: 5 }, (_, i) => ({ status: "fixed", title: `Fixed ${i}`, category: "" }));
+    const out = dedupeResolvedCards([...many, ...fixed]);
+    expect(out.filter((c) => c.status === "dismissed")).toHaveLength(kDoctorHistoryMaxPerStatus);
+    expect(out.filter((c) => c.status === "fixed")).toHaveLength(5);
+    expect(out[0].title).toBe("Finding 0");
+    expect(out.some((c) => c.title === `Finding ${kDoctorHistoryMaxPerStatus + 14}`)).toBe(false);
+  });
+
+  it("tolerates an empty or missing list", () => {
+    expect(dedupeResolvedCards([])).toEqual([]);
+    expect(dedupeResolvedCards()).toEqual([]);
+  });
+});

--- a/tests/server/fix-batch-regressions.test.js
+++ b/tests/server/fix-batch-regressions.test.js
@@ -151,5 +151,44 @@ describe("diff-review fix-batch regressions", () => {
         fs.rmSync(hangingWorkerPath, { force: true });
       }
     });
+
+    it("re-opens the respawn budget after the cooldown instead of staying dark until restart (F112)", async () => {
+      const {
+        createWorkspaceSnapshotWorkerClient,
+        kMaxSnapshotWorkerRespawns,
+      } = require("../../lib/server/doctor/workspace-fingerprint");
+      const alwaysHangPath = path.join(os.tmpdir(), `hang-forever-worker-${process.pid}.js`);
+      fs.writeFileSync(
+        alwaysHangPath,
+        `const { parentPort } = require("worker_threads"); parentPort.on("message", () => {});`,
+      );
+      let nowMs = 1_000_000;
+      const client = createWorkspaceSnapshotWorkerClient({
+        workerScriptPath: alwaysHangPath,
+        requestTimeoutMs: 40,
+        respawnCooldownMs: 1000,
+        now: () => nowMs,
+      });
+      try {
+        for (let i = 0; i < kMaxSnapshotWorkerRespawns; i += 1) {
+          await expect(client.computeWorkspaceSnapshotAsync("/hang")).rejects.toThrow(
+            "Workspace snapshot worker timed out",
+          );
+        }
+        // Cap tripped: an immediate request is refused up front…
+        await expect(client.computeWorkspaceSnapshotAsync("/hang")).rejects.toThrow(
+          "respawn cap reached",
+        );
+        // …but once the cooldown has passed the client spawns again (and this
+        // worker still hangs, so it times out rather than being refused).
+        nowMs += 1001;
+        await expect(client.computeWorkspaceSnapshotAsync("/hang")).rejects.toThrow(
+          "Workspace snapshot worker timed out",
+        );
+      } finally {
+        await client.terminate();
+        fs.rmSync(alwaysHangPath, { force: true });
+      }
+    });
   });
 });

--- a/tests/server/routes-doctor.test.js
+++ b/tests/server/routes-doctor.test.js
@@ -544,6 +544,18 @@ describe("server/routes/doctor", () => {
     expect(res.status).toBe(200);
     expect(res.body.settings.autoRunEnabled).toBe(false);
   });
+
+  it("GET /api/doctor/runs prefers the lean summaries reader when the service exposes it (F110)", async () => {
+    const doctorService = createDoctorService();
+    doctorService.listDoctorRunSummaries = vi.fn(() => [{ id: 7, status: "completed", cardCount: 2 }]);
+    const app = createApp(doctorService);
+    const res = await request(app).get("/api/doctor/runs?limit=3");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, runs: [{ id: 7, status: "completed", cardCount: 2 }] });
+    expect(doctorService.listDoctorRunSummaries).toHaveBeenCalledWith({ limit: 3 });
+    // The full-model reader (manifest + rawResult parse per row) is not used for the poll.
+    expect(doctorService.listDoctorRuns).not.toHaveBeenCalled();
+  });
 });
 
 describe("server/routes/doctor review-batch regressions", () => {


### PR DESCRIPTION
Fix wave, PR 9a of the sequence (stacked on #69 → #68 → #67 → #66 → #65 → #63 → #62 → #61 → #60; merges into `kolkata-v4-pr8c`). Audit batch 23: Doctor. Version **0.9.82**.

## What changed

- **F109 (P2)** — `det:skills-bloat` used one `sourceKey` for the P2 near-limit nudge and the P1 over-limit escalation, so dismissing the nudge permanently hid the escalation. Keys are now `det:skills-bloat:near` / `det:skills-bloat:over` (the doctrine `det:memory-budget:near/over` already follows). **Operator-visible**: a previously dismissed nudge resurfaces once under its new key (CHANGELOG notes it).
- **F110 (P2)** — `GET /api/doctor/runs` (polled 15s idle / 2s during a run) JSON.parsed and re-serialized up to three multi-MB workspace manifests plus rawResult payloads per poll for fields the Doctor tab never reads (`id`, `status`, counts). The route now prefers the service's lean `listDoctorRunSummaries` (falls back to `listDoctorRuns` for older doubles); `/api/doctor/runs/:id` keeps the full model.
- **F111** — the LLM prompt rendered every historical dismissed/fixed card row (reuse runs clone rows every run; never pruned) with no dedupe or cap, and the run's `--params` exec argument had no byte budget unlike `requestCardFix`. `dedupeResolvedCards` (status+title+category, 40 per status, newest first) and the same `kDoctorFixParamsMaxBytes` check: history is dropped first; the run fails with a clear error only if the prompt still cannot fit.
- **F112** — the fingerprint worker's respawn cap (3 consecutive failures) had no runtime recovery, so three request timeouts from an environmental stall blinded the scheduled drift trigger until an AlphaClaw restart. The budget re-opens after a 10-minute cooldown (`respawnCooldownMs`/`now` injectable for tests).
- **F113** — the env signature hashed the model catalog's `source` label (`openclaw` ↔ `cache` flips on every restart and Models-tab refresh), firing spurious scheduled scans. Only model rows are hashed.
- **F114** — `normalizeEvidenceItem` passed arbitrary keys through and `captureEvidenceSnippets` never cleared a pre-existing `snippet`, so LLM/import-supplied excerpts rendered as server-read "snapshot" blocks. Evidence is whitelisted to `type/text/path/startLine/endLine`; `snippet` is always server-set or absent.

## Overlap / reconciliation
No open PR touches `lib/server/doctor/*` or `routes/doctor.js`. `origin/main` is still v0.9.72; renumber in the final pre-merge commit if that changes.

## Supersedes recent work
None: the doctor modules touched predate 2026-08-28 (Drift Doctor waves #27 / #50 are older than 7 days).

## Verification
- `npm test` (Node 22, sandbox `OPENCLAW_*` env unset): see the final run noted in the PR conversation.
- Extended: `doctor-deterministic-checks` (key split + near/over test), `routes-doctor` (+1), `doctor-service` (+3 dedupe), `doctor-normalize` (+1), `fix-batch-regressions` (+1 cooldown).
- F113 has no dedicated test seam (the signature is computed inside the service closure); the change removes one field from a hashed payload and the existing scheduled-scan tests pass unchanged.
- No `lib/public/js` change. Container tier not runnable here (no Docker); CI's Container E2E runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/897cdaac-c48b-433c-8ab5-3f1ca0b5fe30)
