### PR TITLE
v0.9.83 fix: chat — binary parts out of history text, pending-send error guard, outbox confirm/ordering/ack-timeout/page-scoped fixes, history-gated resend, resume keeps the live row (fix wave PR 9b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to AlphaClaw are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow this repository's `package.json` release counter.
 
+## [0.9.83] - 2026-09-04
+
+Fix wave, PR 9b — chat server and chat UI.
+
+### Fixed
+- **Binary transcript parts scraped into chat rows** (audit F116). Image,
+  audio and file parts fell through to the unknown-shape scraper, so the `type`
+  literal, MIME type and base64 payload landed in the history row text (and in
+  live tool-result text). Typed parts are text-only now; known binary types
+  yield nothing.
+- **A runId-less chat error failed a pending send** (F119). The `chat`
+  `state:error` branch lacked the lifecycle-end guard, so a session-routed
+  error from a FOREIGN run during our send window persisted a non-retryable
+  failure and orphan-aborted our own run. Only started records take error
+  terminals.
+- **Never-sent queued messages deleted by the history merge** (F122). The
+  outbox confirm matched a queued item against an older identical user row
+  inside the skew window; only items that were actually sent can confirm.
+- **Acked user bubble rendered below the streaming reply** (F123). Sent
+  optimistic bubbles now render above the live rows of the run they started;
+  unsent ones stay at the bottom.
+- **Ack timeout wedged the session as "Queued" with typing dots** (F124). The
+  outbox requeued the item but nothing left `pendingSend`, so it never
+  auto-flushed until Stop. An `ACK_TIMEOUT` event returns the session to idle.
+- **Navigating away from /chat re-ran restoreOnLoad** (F125). Every route
+  change relabelled queued messages "pending when the page closed" and stopped
+  auto-sending them; the outbox is now one per page load.
+- **Reconnect merge could drop the still-streaming reply** (F126).
+  `RESUME_ATTACH` cleared `activeMessageId`; `hello.activeRuns` and the
+  `resumed` frame now carry the live row's `messageId` and the reducer never
+  clears a known one.
+- **Blind re-send of acked messages after a socket drop** (F127). Acked items
+  were re-queued on a 5s timer with no history gate — a duplicate turn past the
+  bridge's 10-minute dedupe window. They now wait for the reconnect's history
+  merge (30s staleness fallback).
+- Composer said "Queue" in Limited (legacy) mode although sends fire
+  immediately (F128); the message list re-arms auto-scroll on session switch
+  (F129).
+
+### Notes
+- Tests: new `chat-history.test.js`; extended `chat-send-outbox`,
+  `chat-run-state`, `chat-transcript-store`, `chat-ws-bridge` (F119 guard;
+  the stale "cleans up run targets" test now asserts persist-through-close).
+  `docs/designs/chat-reliability.md` records the new invariants. Composer and
+  message-list changes are covered by review only (no component harness).
+
 ## [0.9.82] - 2026-09-04
 
 Fix wave, PR 9a — Doctor.

--- a/docs/designs/chat-reliability.md
+++ b/docs/designs/chat-reliability.md
@@ -173,6 +173,21 @@ fallback keeps history readable when the socket can't connect.
 - **H13** foreign-run event buffer caps (64 runs × 200 events, FIFO evict).
 - **MW5** realtime latch semantics (connection.js httpFallback).
 - **C2** browser socket 'error' handling (close quietly, never crash).
+- **Fix wave PR 9b (v0.9.83)** — outbox and transcript invariants pinned by
+  `tests/frontend/chat-*.test.js`: (1) only an item that was actually SENT
+  (`sentAt`/`ackedAt`) can be confirmed against a history row — a never-sent
+  queued item is never deleted by the merge; (2) sent (inflight/acked)
+  optimistic bubbles render ABOVE the live assistant/tool rows of the run they
+  started, unsent ones below; (3) an ack timeout exits `pendingSend`
+  (`ACK_TIMEOUT` → idle) so the requeued item auto-flushes; (4) the outbox is
+  one per page load, not per `/chat` mount (`restoreOnLoad` runs once); (5)
+  acked items whose socket died wait for the reconnect's history merge
+  (`awaitingHistoryAt` → `releaseAwaitingHistory`, 30s staleness fallback)
+  before any re-send — never a blind 5s timer; (6) `RESUME_ATTACH` carries the
+  live row's `messageId` (from `hello.activeRuns` and the `resumed` frame) and
+  never clears a known one. Server side: typed non-text history parts are never
+  scraped for text; a runId-less session-routed `chat` error does not finalize
+  a pending send (same guard as lifecycle end).
 - Old-bundle compat: legacy `message` frames (no clientMsgId) work — the
   bridge mints an id; validation/errors surface as plain `error` frames;
   `done.stopped === true` stays on stop terminals permanently.

--- a/lib/public/js/components/chat/composer.js
+++ b/lib/public/js/components/chat/composer.js
@@ -73,7 +73,9 @@ export const Composer = ({
   );
   const oversized = draftBytes > maxContentBytes;
   const sendDisabled = !selectedSessionKey || !String(draft || "").trim() || oversized;
-  const willQueue = runActive || connectionMode !== "online";
+  // Limited (legacy) mode sends immediately (fix wave F128): the label must
+  // not promise a queue that never forms.
+  const willQueue = runActive || (connectionMode !== "online" && connectionMode !== "legacy");
 
   const handleKeyDown = useCallback(
     (event) => {

--- a/lib/public/js/components/chat/message-list.js
+++ b/lib/public/js/components/chat/message-list.js
@@ -54,6 +54,15 @@ export const MessageList = ({
     setShowJumpPill(false);
   }, []);
 
+  // A session switch re-arms auto-scroll (fix wave F129): revisiting a cached
+  // session used to open at the previous session's stale scroll position.
+  useEffect(() => {
+    shouldAutoScrollRef.current = true;
+    setShowJumpPill(false);
+    const threadElement = threadRef.current;
+    if (threadElement) threadElement.scrollTop = threadElement.scrollHeight;
+  }, [selectedSessionKey]);
+
   useEffect(() => {
     const threadElement = threadRef.current;
     if (!threadElement) return;

--- a/lib/public/js/components/chat/run-state.js
+++ b/lib/public/js/components/chat/run-state.js
@@ -141,15 +141,36 @@ export const reduceRunState = (state = createSessionRunState(), event = {}) => {
       return state;
     case "CONFIRM_FLUSH":
       return { ...state, holdFlush: false };
-    case "RESUME_ATTACH":
+    case "RESUME_ATTACH": {
+      const messageId = String(event.messageId || "");
+      const runId = String(event.runId || "");
+      // Already attached to this run (fix wave F126): a late `resumed` frame
+      // may bring the messageId the hello-time attach lacked — fill it in,
+      // never clear a known one.
+      if (state.phase === kRunning && state.activeRunId === runId) {
+        if (!messageId || state.activeMessageId === messageId) return state;
+        return { ...state, activeMessageId: messageId };
+      }
       if (state.phase !== kIdle && state.phase !== kInterruptedLocal) return state;
       return {
         ...state,
         phase: kRunning,
-        activeRunId: String(event.runId || ""),
-        activeMessageId: String(event.messageId || ""),
+        activeRunId: runId,
+        activeMessageId: messageId || String(state.activeMessageId || ""),
         assistantStreamStarted: true,
       };
+    }
+    // Ack timeout on the in-flight send (fix wave F124): the outbox requeues
+    // the item; the session must leave pendingSend or canAutoFlush never
+    // re-sends it and the UI shows "Queued" + typing dots until Stop.
+    case "ACK_TIMEOUT": {
+      if (state.phase !== kPendingSend) return state;
+      const clientMsgId = String(event.clientMsgId || "");
+      if (state.activeClientMsgId && clientMsgId && clientMsgId !== state.activeClientMsgId) {
+        return state;
+      }
+      return toIdle(state, { failureCode: "ack_timeout" });
+    }
     case "RESUME_FAILED": {
       const runId = String(event.runId || "");
       if (state.phase !== kRunning && state.phase !== kInterruptedLocal) return state;

--- a/lib/public/js/components/chat/send-outbox.js
+++ b/lib/public/js/components/chat/send-outbox.js
@@ -23,6 +23,10 @@ export const kRetryBaseMs = 2_000;
 export const kRetryMaxMs = 30_000;
 export const kMaxAutoAttempts = 5;
 export const kBusyRecheckMs = 5_000;
+// Acked items whose socket died wait for the reconnect's history merge to
+// confirm delivery before they may be re-sent (fix wave F127); past this the
+// gate opens regardless so a history outage can never strand them.
+export const kAwaitingHistoryMaxMs = 30_000;
 
 const kPersistedStatuses = new Set(["queued", "inflight", "acked", "failed", "unknown"]);
 
@@ -186,13 +190,18 @@ export const createSendOutbox = ({
   // Ack timeout: an inflight item whose ack never came goes back to queued
   // (auto-retry — the bridge dedupes by clientMsgId, so a retry can never
   // duplicate a turn) until the attempt cap, then parks as failed.
-  const sweepAckTimeouts = () => {
+  const sweepAckTimeouts = ({ onTimeout = () => {} } = {}) => {
     const nowMs = now();
     let changed = false;
     for (const item of items) {
       if (item.status !== "inflight") continue;
       if (nowMs - item.sentAt < kAckTimeoutMs) continue;
       changed = true;
+      // Callers use this to leave the pendingSend run state (fix wave F124):
+      // without that exit the requeued item never auto-flushes.
+      try {
+        onTimeout({ clientMsgId: item.clientMsgId, sessionKey: item.sessionKey });
+      } catch {}
       if (item.attempts >= kMaxAutoAttempts) {
         item.status = "failed";
         item.lastError = {
@@ -288,17 +297,43 @@ export const createSendOutbox = ({
   const requeueAllInflight = () => {
     let changed = false;
     for (const item of items) {
-      if (item.status !== "inflight" && item.status !== "acked") continue;
-      // Acked items get a short hold: the reconnect history merge usually
-      // CONFIRMS delivery (removing the item) before this fires — resending
-      // is then dedupe-safe but pointless, and past the bridge's 10-minute
-      // dedupe window it would be a real duplicate.
-      const wasAcked = item.status === "acked";
+      if (item.status === "inflight") {
+        item.status = "queued";
+        item.nextAttemptAt = 0;
+        changed = true;
+        continue;
+      }
+      if (item.status !== "acked") continue;
+      // Acked items are gated on history (fix wave F127): the reconnect's
+      // history merge CONFIRMS delivery (removing the item) in the common
+      // case; only an item history does not show is re-queued, via
+      // releaseAwaitingHistory. A blind close-relative timer re-sent past the
+      // bridge's 10-minute dedupe window — a real duplicate turn.
+      if (!item.awaitingHistoryAt) {
+        item.awaitingHistoryAt = now();
+        changed = true;
+      }
+    }
+    if (changed) persist();
+  };
+
+  // History for `sessionKey` merged (or failed): acked items it did not
+  // confirm go back to queued, immediately eligible. `force` releases every
+  // session (the flush loop's staleness fallback).
+  const releaseAwaitingHistory = (sessionKey = "", { force = false, olderThanMs = 0 } = {}) => {
+    const nowMs = now();
+    let changed = false;
+    for (const item of items) {
+      if (item.status !== "acked" || !item.awaitingHistoryAt) continue;
+      if (!force && String(item.sessionKey) !== String(sessionKey)) continue;
+      if (olderThanMs > 0 && nowMs - item.awaitingHistoryAt < olderThanMs) continue;
+      delete item.awaitingHistoryAt;
       item.status = "queued";
-      item.nextAttemptAt = wasAcked ? now() + 5000 : 0;
+      item.nextAttemptAt = 0;
       changed = true;
     }
     if (changed) persist();
+    return changed;
   };
 
   // Reload restore (D5): non-terminal items become `failed` — a reload never
@@ -352,6 +387,7 @@ export const createSendOutbox = ({
     listAll: () => items.slice(),
     requeue,
     requeueAllInflight,
+    releaseAwaitingHistory,
     restoreOnLoad,
     clearAll,
     isMemoryOnly: () => memoryOnly,

--- a/lib/public/js/components/chat/transcript-store.js
+++ b/lib/public/js/components/chat/transcript-store.js
@@ -174,6 +174,10 @@ export const mergeHistory = ({
   const historyText = (value) =>
     String(value || "").trim().replace(/^\[.*?\]\s*/, "");
   for (const item of outboxItems) {
+    // Only items that were actually SENT can be confirmed (fix wave F122): a
+    // queued item that never left the outbox matched an older identical user
+    // row inside the skew window and was deleted unsent.
+    if (!Number(item.sentAt) && !Number(item.ackedAt)) continue;
     const ackedAt = Number(item.ackedAt) || Number(item.createdAt) || 0;
     const match = merged.find(
       (row) =>
@@ -248,13 +252,18 @@ export const mergeHistory = ({
  */
 export const composeVisibleMessages = ({ messages = [], outboxItems = [] }) => {
   if (!outboxItems.length) return messages;
-  return [
-    ...messages,
-    ...outboxItems
-      .slice()
-      .sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0))
-      .map((item) => createOptimisticUserMessage({ item })),
-  ];
+  const sorted = outboxItems
+    .slice()
+    .sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0))
+    .map((item) => createOptimisticUserMessage({ item }));
+  // Items whose send is in flight/acked started the run whose LIVE rows are
+  // streaming — they belong above those rows (fix wave F123); unsent items
+  // are newer activity and stay at the bottom.
+  const firstLive = messages.findIndex((message) => message?.live);
+  if (firstLive < 0) return [...messages, ...sorted];
+  const sent = sorted.filter((m) => m.pendingState === "acked" || m.pendingState === "inflight");
+  const unsent = sorted.filter((m) => m.pendingState !== "acked" && m.pendingState !== "inflight");
+  return [...messages.slice(0, firstLive), ...sent, ...messages.slice(firstLive), ...unsent];
 };
 
 /**

--- a/lib/public/js/components/chat/use-chat-store.js
+++ b/lib/public/js/components/chat/use-chat-store.js
@@ -3,7 +3,7 @@ import { authFetch } from "../../lib/api.js";
 import { kChatSendOutboxStorageKey } from "../../lib/storage-keys.js";
 import { showToast } from "../toast.js";
 import { useChatConnection } from "./use-chat-connection.js";
-import { createSendOutbox } from "./send-outbox.js";
+import { createSendOutbox, kAwaitingHistoryMaxMs } from "./send-outbox.js";
 import {
   createSessionRunState,
   reduceRunState,
@@ -23,6 +23,28 @@ import {
   buildStopFrame,
   buildHistoryFrame,
 } from "./chat-protocol.js";
+
+// Page-scoped outbox registry (fix wave F125). Handlers are per mount (they
+// close over the current mount's setState); the outbox instance is not.
+const kSharedOutboxes = new Map();
+const acquireSharedOutbox = ({ storage, storageKey, onPersistError, onChange }) => {
+  let entry = kSharedOutboxes.get(storageKey);
+  if (!entry) {
+    entry = { handlers: { onPersistError, onChange }, outbox: null };
+    entry.outbox = createSendOutbox({
+      storage,
+      storageKey,
+      onPersistError: (...args) => entry.handlers.onPersistError?.(...args),
+      onChange: (...args) => entry.handlers.onChange?.(...args),
+    });
+    entry.outbox.restoreOnLoad();
+    kSharedOutboxes.set(storageKey, entry);
+    return entry.outbox;
+  }
+  entry.handlers = { onPersistError, onChange };
+  return entry.outbox;
+};
+export const resetSharedChatOutboxesForTests = () => kSharedOutboxes.clear();
 
 const kHistoryDedupeMs = 2000;
 const kFlushTickMs = 1000;
@@ -71,13 +93,16 @@ export const useChatStore = ({
     } catch {
       storage = null;
     }
-    outboxRef.current = createSendOutbox({
+    // One outbox per PAGE LOAD, not per mount (fix wave F125): the chat route
+    // unmounts on every navigation away from /chat, and a per-mount outbox
+    // re-ran restoreOnLoad — queued messages stopped auto-sending and were
+    // relabelled "pending when the page closed", acked ones flashed "Not sent".
+    outboxRef.current = acquireSharedOutbox({
       storage,
       storageKey: kChatSendOutboxStorageKey,
       onPersistError: () => setPersistWarning(true),
       onChange: () => setOutboxVersion((version) => version + 1),
     });
-    outboxRef.current.restoreOnLoad();
     if (outboxRef.current.isMemoryOnly() && storage !== null) {
       setPersistWarning(true);
     }
@@ -148,6 +173,8 @@ export const useChatStore = ({
         lastFetchedAt: Date.now(),
       });
       lastFetchAtBySessionRef.current[sessionKey] = Date.now();
+      // History merged: acked items it did not confirm may be re-sent (F127).
+      outbox.releaseAwaitingHistory(sessionKey);
     },
     [outbox, setHistoryMeta],
   );
@@ -180,6 +207,15 @@ export const useChatStore = ({
         lastSeqBySessionRef.current[sessionKey] = seq;
       }
       if (type === "resumed") {
+        // Fill in the live row's stream id (F126) so the forced merge below
+        // keeps the still-streaming assistant row as active, never superseded.
+        if (payload.messageId) {
+          applyRunEvent(sessionKey, {
+            type: "RESUME_ATTACH",
+            runId: String(payload.runId || ""),
+            messageId: String(payload.messageId || ""),
+          });
+        }
         if (payload.gap === true) {
           // The replay buffer could not cover our cursor — reconcile fully.
           requestHistoryRef.current(sessionKey, { force: true });
@@ -335,7 +371,11 @@ export const useChatStore = ({
         if (!sessionKey || !runId) continue;
         const afterSeq = lastSeqBySessionRef.current[sessionKey] || 0;
         conn.sendFrame({ type: "resume", sessionKey, runId, afterSeq });
-        applyRunEvent(sessionKey, { type: "RESUME_ATTACH", runId });
+        applyRunEvent(sessionKey, {
+          type: "RESUME_ATTACH",
+          runId,
+          messageId: String(run?.messageId || ""),
+        });
       }
       // A run that FINISHED during the outage is absent from activeRuns — its
       // terminal went to the dead socket. Sessions still marked
@@ -418,10 +458,12 @@ export const useChatStore = ({
             loading: false,
             error: err?.message || "Could not load chat history.",
           });
+          // No history to confirm against — do not strand acked items (F127).
+          outbox.releaseAwaitingHistory(normalized);
         }
       })();
     },
-    [appendDebugEvent, applyHistoryPayload, setHistoryMeta],
+    [appendDebugEvent, applyHistoryPayload, outbox, setHistoryMeta],
   );
   requestHistoryRef.current = requestHistory;
 
@@ -465,7 +507,14 @@ export const useChatStore = ({
   );
 
   const flushTick = useCallback(() => {
-    outbox.sweepAckTimeouts();
+    outbox.sweepAckTimeouts({
+      // Leave pendingSend so the requeued item can flush again (F124).
+      onTimeout: ({ sessionKey, clientMsgId }) =>
+        applyRunEvent(sessionKey, { type: "ACK_TIMEOUT", clientMsgId }),
+    });
+    // Staleness fallback for the history gate (F127): a session whose history
+    // never answered must not hold its acked items forever.
+    outbox.releaseAwaitingHistory("", { force: true, olderThanMs: kAwaitingHistoryMaxMs });
     const queuedSessions = new Set(
       outbox
         .listAll()
@@ -479,7 +528,7 @@ export const useChatStore = ({
       if (!item) continue;
       flushItem(item);
     }
-  }, [flushItem, outbox]);
+  }, [applyRunEvent, flushItem, outbox]);
   flushTickRef.current = flushTick;
 
   useEffect(() => {

--- a/lib/server/chat/history.js
+++ b/lib/server/chat/history.js
@@ -5,6 +5,20 @@
 const nodeCrypto = require("node:crypto");
 const { kMarkerStatuses } = require("./protocol");
 
+// Typed parts whose payload is never transcript text (fix wave F116).
+const kBinaryPartTypes = new Set([
+  "image",
+  "image_url",
+  "input_image",
+  "audio",
+  "input_audio",
+  "video",
+  "file",
+  "document",
+  "binary",
+  "attachment",
+]);
+
 const collectHistoryTextFragments = (value) => {
   if (typeof value === "string") {
     return value.length > 0 ? [value] : [];
@@ -24,10 +38,17 @@ const collectHistoryTextFragments = (value) => {
       partType === "toolcall" ||
       partType === "tool_call" ||
       partType === "toolresult" ||
-      partType === "tool_result"
+      partType === "tool_result" ||
+      kBinaryPartTypes.has(partType)
     ) {
       return [];
     }
+    // Any OTHER typed part (fix wave F116): read its text-ish fields only.
+    // The Object.values fallback below exists for UNTYPED unknown block
+    // shapes; on a typed part it scraped the `type` literal, mime types and
+    // base64 payloads into the transcript row.
+    return [value.text, value.message, value.content, value.parts, value.value]
+      .flatMap((entry) => collectHistoryTextFragments(entry));
   }
 
   const textFields = [

--- a/lib/server/chat/index.js
+++ b/lib/server/chat/index.js
@@ -321,6 +321,7 @@ const createChatWsService = ({
         .map((record) => ({
           sessionKey: record.sessionKey,
           runId: record.runId,
+          messageId: record.messageId || "",
           seq: record.lastSeq,
         })),
     });

--- a/lib/server/chat/send-service.js
+++ b/lib/server/chat/send-service.js
@@ -692,6 +692,12 @@ const createSendService = ({
       if (!record) return;
       record.lastEventAt = now();
       if (String(payload?.state || "") === "error") {
+        // Same guard as the lifecycle end (fix wave F119): a session-routed
+        // error without a runId during our send window can belong to a
+        // FOREIGN run; failing our still-pending record would persist a
+        // non-retryable outcome and orphan-abort our own run when the RPC
+        // resolves. Only STARTED records take chat error terminals.
+        if (!record.runId) return;
         finalizeAndEmit(record, "error", "confirmed", {
           errorCode: "run_failed",
           detail: "Something went wrong connecting to the agent.",
@@ -801,6 +807,10 @@ const createSendService = ({
       type: "resumed",
       sessionKey,
       runId,
+      // The live assistant row's stream id (fix wave F126): without it the
+      // client's RESUME_ATTACH cleared activeMessageId and the forced
+      // post-reconnect merge could drop the still-streaming row as superseded.
+      messageId: record.messageId || "",
       fromSeq: firstSeq === null ? afterSeq + 1 : firstSeq,
       toSeq: record.lastSeq,
       gap: gap === true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.82",
+  "version": "0.9.83",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alphaclaw",
-      "version": "0.9.82",
+      "version": "0.9.83",
       "license": "MIT",
       "dependencies": {
         "compression": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.82",
+  "version": "0.9.83",
   "publishConfig": {
     "access": "public"
   },

--- a/tests/frontend/chat-run-state.test.js
+++ b/tests/frontend/chat-run-state.test.js
@@ -371,3 +371,46 @@ describe("run-state: STARTED while stopping", () => {
     expect(state.phase).toBe("idle");
   });
 });
+
+describe("frontend/chat run-state fix wave PR 9b (F124 ack timeout, F126 resume messageId)", () => {
+  it("ACK_TIMEOUT returns a pendingSend session to idle so the requeued item can auto-flush", () => {
+    const pending = reduceAll([{ type: "OUTBOX_INFLIGHT", clientMsgId: "c1" }]);
+    expect(pending.phase).toBe(kPendingSend);
+    expect(canAutoFlush(pending)).toBe(false);
+    const idle = reduceRunState(pending, { type: "ACK_TIMEOUT", clientMsgId: "c1" });
+    expect(idle.phase).toBe(kIdle);
+    expect(idle.lastTerminal).toMatchObject({ failureCode: "ack_timeout" });
+    expect(canAutoFlush(idle)).toBe(true);
+    expect(idle.holdFlush).not.toBe(true);
+  });
+
+  it("ACK_TIMEOUT for another clientMsgId, or outside pendingSend, is ignored", () => {
+    const pending = reduceAll([{ type: "OUTBOX_INFLIGHT", clientMsgId: "c1" }]);
+    expect(reduceRunState(pending, { type: "ACK_TIMEOUT", clientMsgId: "other" })).toBe(pending);
+    const running = reduceAll([
+      { type: "OUTBOX_INFLIGHT", clientMsgId: "c1" },
+      { type: "STARTED", clientMsgId: "c1", runId: "r1", messageId: "m1" },
+    ]);
+    expect(reduceRunState(running, { type: "ACK_TIMEOUT", clientMsgId: "c1" })).toBe(running);
+  });
+
+  it("RESUME_ATTACH carries the live row's messageId and never clears a known one", () => {
+    const attached = reduceRunState(createSessionRunState(), {
+      type: "RESUME_ATTACH",
+      runId: "r1",
+      messageId: "m1",
+    });
+    expect(attached).toMatchObject({ phase: kRunning, activeRunId: "r1", activeMessageId: "m1" });
+    // A hello-time attach without the id keeps a previously known id…
+    const known = { ...createSessionRunState(), activeMessageId: "m1" };
+    expect(reduceRunState(known, { type: "RESUME_ATTACH", runId: "r1" }).activeMessageId).toBe("m1");
+    // …and a later `resumed` frame fills an empty one in while already running.
+    const idless = reduceRunState(createSessionRunState(), { type: "RESUME_ATTACH", runId: "r1" });
+    expect(idless.activeMessageId).toBe("");
+    const filled = reduceRunState(idless, { type: "RESUME_ATTACH", runId: "r1", messageId: "m1" });
+    expect(filled).toMatchObject({ phase: kRunning, activeRunId: "r1", activeMessageId: "m1" });
+    // Identity-stable when nothing changes; a different run is still ignored while running.
+    expect(reduceRunState(filled, { type: "RESUME_ATTACH", runId: "r1", messageId: "m1" })).toBe(filled);
+    expect(reduceRunState(filled, { type: "RESUME_ATTACH", runId: "r2", messageId: "m2" })).toBe(filled);
+  });
+});

--- a/tests/frontend/chat-send-outbox.test.js
+++ b/tests/frontend/chat-send-outbox.test.js
@@ -449,12 +449,11 @@ describe("send-outbox: socket-death requeue and live-eviction warning", () => {
     expect(outbox.nextEligible("s2")?.clientMsgId).toBe(b.clientMsgId);
   });
 
-  it("requeueAllInflight also requeues ACKED items, with a hold for history confirmation", async () => {
-    // The socket died after ack but before a terminal: the run's outcome went
-    // to the dead socket and pending runs are never advertised in
-    // hello.activeRuns — NOT requeueing strands the item as "sent, never
-    // settled". The short hold lets the reconnect history merge confirm
-    // delivery (removing the item) before any dedupe-safe resend fires.
+  it("requeueAllInflight holds ACKED items for history confirmation; releaseAwaitingHistory re-queues the unconfirmed (F127)", async () => {
+    // The socket died after ack but before a terminal. A blind close-relative
+    // timer re-sent past the bridge's 10-minute dedupe window — a duplicate
+    // turn. Acked items now wait for the reconnect's history merge: confirmed
+    // ones are removed by the merge, only the rest go back to queued.
     const { createSendOutbox } = await import(
       "../../lib/public/js/components/chat/send-outbox.js"
     );
@@ -468,13 +467,65 @@ describe("send-outbox: socket-death requeue and live-eviction warning", () => {
       random: () => 0.5,
     });
     const item = outbox.enqueue({ sessionKey: "s1", content: "acked one" });
+    const other = outbox.enqueue({ sessionKey: "s2", content: "acked two" });
     outbox.markInflight(item.clientMsgId);
     outbox.markAcked(item.clientMsgId);
+    outbox.markInflight(other.clientMsgId);
+    outbox.markAcked(other.clientMsgId);
     outbox.requeueAllInflight();
-    expect(outbox.listAll()[0].status).toBe("queued");
+    // Still acked (not queued), stamped as awaiting history; nothing eligible.
+    expect(outbox.listAll().map((i) => i.status)).toEqual(["acked", "acked"]);
+    expect(outbox.listAll()[0].awaitingHistoryAt).toBe(nowRef.now);
     expect(outbox.nextEligible("s1")).toBeNull();
-    nowRef.now += 5_000;
+    nowRef.now += 60_000;
+    expect(outbox.nextEligible("s1")).toBeNull();
+
+    // History for s1 merged and did NOT confirm the item → re-queued now.
+    expect(outbox.releaseAwaitingHistory("s1")).toBe(true);
     expect(outbox.nextEligible("s1")?.clientMsgId).toBe(item.clientMsgId);
+    expect(outbox.listAll().find((i) => i.clientMsgId === item.clientMsgId).awaitingHistoryAt).toBeUndefined();
+    // s2 is untouched until ITS history answers…
+    expect(outbox.nextEligible("s2")).toBeNull();
+    // …or the staleness fallback releases everything older than the bound.
+    expect(outbox.releaseAwaitingHistory("", { force: true, olderThanMs: 120_000 })).toBe(false);
+    nowRef.now += 60_001;
+    expect(outbox.releaseAwaitingHistory("", { force: true, olderThanMs: 120_000 })).toBe(true);
+    expect(outbox.nextEligible("s2")?.clientMsgId).toBe(other.clientMsgId);
+    // Confirmed delivery beats the gate: a confirmed item simply disappears.
+    outbox.confirmDelivered(item.clientMsgId);
+    expect(outbox.listAll().map((i) => i.clientMsgId)).toEqual([other.clientMsgId]);
+  });
+
+  it("sweepAckTimeouts reports each timed-out item so the run state can leave pendingSend (F124)", async () => {
+    const { createSendOutbox, kAckTimeoutMs } = await import(
+      "../../lib/public/js/components/chat/send-outbox.js"
+    );
+    const nowRef = { now: 1_000_000 };
+    let uuidCounter = 0;
+    const outbox = createSendOutbox({
+      storage: null,
+      storageKey: "t",
+      now: () => nowRef.now,
+      uuid: () => `to-${(uuidCounter += 1)}`,
+      random: () => 0.5,
+    });
+    const item = outbox.enqueue({ sessionKey: "s9", content: "lost ack" });
+    outbox.markInflight(item.clientMsgId);
+    const timeouts = [];
+    nowRef.now += kAckTimeoutMs;
+    expect(outbox.sweepAckTimeouts({ onTimeout: (info) => timeouts.push(info) })).toBe(true);
+    expect(timeouts).toEqual([{ clientMsgId: item.clientMsgId, sessionKey: "s9" }]);
+    // A throwing callback never breaks the sweep.
+    outbox.markInflight(item.clientMsgId);
+    nowRef.now += kAckTimeoutMs;
+    expect(() =>
+      outbox.sweepAckTimeouts({
+        onTimeout: () => {
+          throw new Error("boom");
+        },
+      }),
+    ).not.toThrow();
+    expect(outbox.listAll()[0].status).toBe("queued");
   });
 
   it("warns loudly when the byte cap is forced to evict a LIVE item from storage", async () => {

--- a/tests/frontend/chat-transcript-store.test.js
+++ b/tests/frontend/chat-transcript-store.test.js
@@ -347,3 +347,44 @@ describe("frontend/chat transcript-store markerCopy", () => {
     expect(markerCopy({ kind: "someday-new" })).toBe("This message failed");
   });
 });
+
+describe("frontend/chat transcript-store fix wave PR 9b (F122 confirm gate, F123 ordering)", () => {
+  it("mergeHistory never confirms a NEVER-SENT queued item against an older identical user row (F122)", () => {
+    const confirmed = [];
+    const rows = [historyRow("h1", "user", "deploy it", 1_000)];
+    const queued = { clientMsgId: "q1", content: "deploy it", createdAt: 1_500, status: "queued" };
+    mergeHistory({ current: [], rows, outboxItems: [queued], onConfirmed: (id) => confirmed.push(id) });
+    expect(confirmed).toEqual([]);
+
+    // The same item once actually SENT (sentAt/ackedAt) confirms as before.
+    const sent = { ...queued, status: "acked", sentAt: 1_600, ackedAt: 1_650 };
+    mergeHistory({ current: [], rows, outboxItems: [sent], onConfirmed: (id) => confirmed.push(id) });
+    expect(confirmed).toEqual(["q1"]);
+  });
+
+  it("composeVisibleMessages places sent bubbles above the live rows of their run and unsent ones below (F123)", () => {
+    const messages = [
+      historyRow("h1", "assistant", "welcome", 50),
+      { id: "live:m1", live: true, streamMessageId: "m1", role: "assistant", content: "Hel", createdAt: 300 },
+      { id: "live-tool:1", live: true, role: "tool", content: "Tool call: read", createdAt: 310 },
+    ];
+    const outboxItems = [
+      { clientMsgId: "acked", content: "hi", createdAt: 200, status: "acked", sentAt: 210, ackedAt: 220 },
+      { clientMsgId: "queued", content: "and then?", createdAt: 400, status: "queued" },
+      { clientMsgId: "failed", content: "retry me", createdAt: 350, status: "failed" },
+    ];
+    const visible = composeVisibleMessages({ messages, outboxItems });
+    expect(visible.map((m) => m.id)).toEqual([
+      "h1",
+      "c:acked",
+      "live:m1",
+      "live-tool:1",
+      "c:failed",
+      "c:queued",
+    ]);
+    // No live rows: unchanged append-in-creation-order behavior.
+    const flat = composeVisibleMessages({ messages: [messages[0]], outboxItems });
+    expect(flat.map((m) => m.id)).toEqual(["h1", "c:acked", "c:failed", "c:queued"]);
+    expect(composeVisibleMessages({ messages, outboxItems: [] })).toBe(messages);
+  });
+});

--- a/tests/server/chat-history.test.js
+++ b/tests/server/chat-history.test.js
@@ -1,0 +1,39 @@
+const { normalizeHistoryContent } = require("../../lib/server/chat/history");
+
+// Fix wave F116: typed non-text parts (image/audio/file) must never be
+// scraped into the transcript row — the `type` literal, MIME type and base64
+// payload used to land in the visible text.
+describe("server/chat/history normalizeHistoryContent (typed parts)", () => {
+  const kBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk";
+
+  it("keeps text parts and drops image/audio/file parts entirely", () => {
+    const content = [
+      { type: "text", text: "Here is the screenshot:" },
+      { type: "image", source: { type: "base64", media_type: "image/png", data: kBase64 } },
+      { type: "image_url", image_url: { url: `data:image/png;base64,${kBase64}` } },
+      { type: "audio", data: kBase64, format: "wav" },
+      { type: "file", name: "report.pdf", data: kBase64, mimeType: "application/pdf" },
+      { type: "text", text: "Thoughts?" },
+    ];
+    const text = normalizeHistoryContent(content);
+    expect(text).toBe("Here is the screenshot:Thoughts?");
+    expect(text).not.toMatch(/image|png|audio|wav|pdf|base64|iVBOR/);
+  });
+
+  it("an unknown TYPED part reads only its text-ish fields, never every value", () => {
+    const text = normalizeHistoryContent([
+      { type: "annotation", text: "visible note", payload: "hidden-blob", mime: "x/y" },
+      { type: "widget", value: "shown", data: kBase64 },
+    ]);
+    expect(text).toBe("visible noteshown");
+    expect(text).not.toMatch(/hidden-blob|x\/y|iVBOR/);
+  });
+
+  it("untyped unknown block shapes keep the value scraper (transcript-shape tolerance)", () => {
+    expect(normalizeHistoryContent([{ weird: "still shown", nested: { deeper: "too" } }])).toBe(
+      "still showntoo",
+    );
+    expect(normalizeHistoryContent("plain")).toBe("plain");
+    expect(normalizeHistoryContent([{ type: "thinking", text: "internal" }])).toBe("");
+  });
+});

--- a/tests/server/chat-ws-bridge.test.js
+++ b/tests/server/chat-ws-bridge.test.js
@@ -1037,7 +1037,37 @@ describe("server/chat-ws bridge", () => {
       );
     });
 
-    it("cleans up run targets and pending sends when the browser disconnects", async () => {
+    it("a runId-less, session-routed chat error during the send window does NOT fail the pending send (F119)", async () => {
+      const harness = await startGatewayHarness();
+      const service = createService(harness);
+      const browser = await openBrowser(service);
+
+      let pendingFrame = null;
+      harness.onRequest = (frame) => {
+        if (frame.method === "chat.send") pendingFrame = frame;
+      };
+      browser.send({ type: "message", sessionKey: "pend-1", content: "slow one" });
+      await waitUntil(() => pendingFrame !== null, "pending chat.send");
+
+      // A FOREIGN run finishing badly in the same session, routed by key only.
+      harness.emit({
+        type: "event",
+        event: "chat",
+        payload: { meta: { sessionKey: "pend-1" }, state: "error" },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      expect(browser.messages.some((m) => m.type === "error" && m.sessionKey === "pend-1")).toBe(false);
+
+      // Our send still completes normally when the RPC resolves.
+      harness.respond(pendingFrame.id, { runId: "run-pend-1" });
+      const started = await browser.waitFor(
+        (m) => m.type === "started" && m.sessionKey === "pend-1",
+        "started pend-1",
+      );
+      expect(started.runId).toBe("run-pend-1");
+    });
+
+    it("browser disconnect keeps run records alive (persist-through-close) and the bridge survives late events", async () => {
       const harness = await startGatewayHarness();
       const service = createService(harness);
       const browser = await openBrowser(service);
@@ -1075,9 +1105,27 @@ describe("server/chat-ws bridge", () => {
 
       harness.onRequest = respondEmptyHistory(harness);
       const survivor = await openBrowser(service);
+      // Persist-through-close (fix wave F120, pinned here too): the runs the
+      // dead browser started are still live records, advertised to the next
+      // socket so it can resume them.
+      const survivorHello = await survivor.waitFor((m) => m.type === "hello", "survivor hello");
+      expect(survivorHello.activeRuns.map((run) => run.runId).sort()).toEqual(["run-g1", "run-g2"]);
+      // Their live rows carry the stream id the client needs (F126).
+      for (const run of survivorHello.activeRuns) expect(typeof run.messageId).toBe("string");
       survivor.send({ type: "history", sessionKey: "still-alive" });
       const history = await survivor.waitFor((m) => m.type === "history", "history");
       expect(history.messages).toEqual([]);
+
+      // A lifecycle end for one run finalizes it; the other stays resumable.
+      harness.emit({
+        type: "event",
+        event: "agent",
+        payload: { runId: "run-g1", stream: "lifecycle", data: { phase: "end" } },
+      });
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      const latecomer = await openBrowser(service);
+      const lateHello = await latecomer.waitFor((m) => m.type === "hello", "late hello");
+      expect(lateHello.activeRuns.map((run) => run.runId)).toEqual(["run-g2"]);
     });
   });
 


### PR DESCRIPTION
Fix wave, PR 9b of the sequence (stacked on #70 → #69 → #68 → #67 → #66 → #65 → #63 → #62 → #61 → #60; merges into `kolkata-v4-pr9a`). Audit batches 24 + 25: chat server + chat UI. Version **0.9.83**. No wire-format change (protocol v2 frames untouched; `hello.activeRuns[]` and `resumed` gain an optional `messageId`).

## Server (`lib/server/chat/`)
- **F116 (P2)** — `history.js`: typed non-text parts (image/audio/file/…) fell through to the unknown-shape `Object.values` scraper, so the `type` literal, MIME type and base64 payload became row text (history rows and live tool-result text). Known binary part types yield nothing; any other typed part reads only its text-ish fields; UNTYPED unknown blocks keep the scraper (transcript-shape tolerance). New `tests/server/chat-history.test.js`.
- **F119** — `send-service.js`: the `chat` `state:error` branch lacked the lifecycle-end guard (`if (!record.runId) return`), so a session-routed error from a foreign run during our send window finalized the pending record (persisted non-retryable) and orphan-aborted our own run when the RPC resolved. Test: pending send + runId-less error → no `error` frame; the send still starts.
- **F126 (server half)** — `hello.activeRuns[]` and the `resumed` frame carry `messageId` (the live assistant row's stream id).
- **F120** — the stale "cleans up run targets…" test is renamed and now asserts the documented persist-through-close invariant: the survivor's `hello.activeRuns` lists both runs; a lifecycle end finalizes one and the next hello lists only the other.

## Client (`lib/public/js/components/chat/`)
- **F122 (P2)** — `mergeHistory` confirmed (and deleted) a NEVER-SENT queued item against an older identical user row inside the skew window. Only items with `sentAt`/`ackedAt` can confirm.
- **F123 (P2)** — while a reply streamed, the acked user bubble rendered below the live assistant row until the post-done merge. `composeVisibleMessages` places sent (inflight/acked) bubbles above the run's live rows; unsent ones stay at the bottom.
- **F124 (P2)** — an ack timeout requeued the item but nothing left `pendingSend`, so `canAutoFlush` never re-sent it: "Queued" + typing dots until Stop. `sweepAckTimeouts({ onTimeout })` reports each item; the store dispatches `ACK_TIMEOUT` (pendingSend → idle, `failureCode: ack_timeout`, no holdFlush).
- **F125 (P2)** — the outbox was created per `/chat` mount, so every navigation away re-ran `restoreOnLoad`: queued messages stopped auto-sending and were relabelled "pending when the page closed", acked ones flashed "Not sent". `acquireSharedOutbox` keeps one outbox per page load (handlers rebound per mount; `resetSharedChatOutboxesForTests` exported).
- **F126 (client half)** — `RESUME_ATTACH` passes `messageId` from `hello.activeRuns`; a later `resumed` frame fills an empty `activeMessageId` while running; the reducer never overwrites a known id with `""`. Prevents the forced post-reconnect merge from dropping the still-streaming row as `superseded`.
- **F127 (P2)** — acked items whose socket died were re-queued on a blind close-relative 5s timer — a duplicate `chat.send` past the bridge's 10-minute dedupe window. They now stay `acked` with `awaitingHistoryAt`; `releaseAwaitingHistory(sessionKey)` runs after that session's history merge (or history failure), and the flush loop releases anything older than 30s (`kAwaitingHistoryMaxMs`) so a history outage never strands them. The existing "requeues ACKED items with a hold" test is rewritten to this contract.
- **F128 / F129** — composer no longer says "Queue" in Limited (legacy) mode (sends fire immediately); the message list re-arms auto-scroll on session switch. Covered by review only — there is no component harness for these two files (noted in the CHANGELOG).

`docs/designs/chat-reliability.md` records the new invariants under "Preserved invariants". `npm run build:ui` run (dist is gitignored; CI builds).

## Overlap / reconciliation
No open PR touches chat files. `origin/main` is still v0.9.72; renumber in the final pre-merge commit if that changes.

## Supersedes recent work
None: the chat reliability work (protocol v2, phases 1–5) landed before 2026-08-28; this PR extends the outbox/reducer/merge contracts and rewrites one test's expectation (acked requeue hold → history gate) with the reasoning above.

## Verification
- `npm test` (Node 22, sandbox `OPENCLAW_*` env unset): see the final run noted in the PR conversation.
- New: `tests/server/chat-history.test.js` (3). Extended: `chat-send-outbox` (F127 gate, F124 callback), `chat-run-state` (+3), `chat-transcript-store` (+2), `chat-ws-bridge` (F119, F120/F126).
- Container tier not runnable here (no Docker); CI's Container E2E runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/897cdaac-c48b-433c-8ab5-3f1ca0b5fe30)
