### PR TITLE
v0.9.84 fix: rescue session — Stop for retained sessions, honest auth-gate status, real tmux scrollback, resumed URL wait, adoption while disabled, generation-safe reaper, redacted ids (fix wave PR 10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to AlphaClaw are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versions follow this repository's `package.json` release counter.
 
+## [0.9.84] - 2026-09-04
+
+Fix wave, PR 10 — local Claude Code rescue session.
+
+### Fixed
+- **Stop was missing exactly when the copy said to press it** (audit F130).
+  A session kept for diagnosis (`running_no_url` / `adopted_without_url`)
+  rendered the Error state without a Stop button while the server message
+  read "view the output tail, then Stop to retry". Stop renders for any
+  retained session.
+- **Auth gate collapsed the card to "Probing…"** (F131). A refused Remote
+  Control start nulled the login probe memo, so the status read `probing`
+  (hiding `needs_login`/`error`) until the 60-second probe timer fired. The
+  gate now marks the memo logged-out instead.
+- **Rescue pane scrollback was the 2000-line tmux default** (F132).
+  `set-option -g history-limit 50000` ran before any tmux server existed and
+  failed silently (set-option does not start a server), so adoption's
+  10k/50k re-extraction escalation was inert. `start-server` runs first; a
+  failed limit is surfaced on the result.
+- **A restart mid-URL-wait showed a healthy session as Error** (F134). Boot
+  adoption ignored the persisted `starting` phase and marked the pane
+  `adopted_without_url` without resuming the watcher. An identity-matched pane
+  still inside the URL budget resumes the watcher.
+- **Disabling hid a still-live session after a restart** (F135). Boot
+  reconcile skipped adoption when `CLAUDE_CODE_LOCAL_ENABLED=0`, so the live
+  pane had no warning, no Stop, and a 404 rescue link. Adoption (read-only)
+  runs regardless; only autostart is gated.
+- **Liveness reap could null a successor session** (F136). The reaper
+  re-checks the session generation after its await before clearing state.
+- The raw Remote Control `sessionId` (which reconstructs the account-gated
+  URL) no longer appears in the agent-readable process log (F133).
+
+### Notes
+- Tests: extended `claude-code-local-service`, `claude-code-local-tmux`,
+  `rescue-session-card`.
+
 ## [0.9.83] - 2026-09-04
 
 Fix wave, PR 9b — chat server and chat UI.

--- a/lib/public/js/components/watchdog-tab/rescue-session-card.js
+++ b/lib/public/js/components/watchdog-tab/rescue-session-card.js
@@ -228,6 +228,9 @@ export const WatchdogRescueSessionCard = () => {
   // enabled=0 with a session still live (E2): the kill switch must never cut
   // off an operator mid-rescue, so the card collapses to stop-only.
   const disabledWithLiveSession = state === "disabled" && Boolean(local.startedAt);
+  // Error with a RETAINED live session (running_no_url / adopted_without_url,
+  // fix wave F130): the server copy says "Stop to retry", so Stop must render.
+  const retainedInError = state === "error" && Boolean(local.startedAt);
   const modeDrift =
     Boolean(local.livePermissionMode) &&
     local.permissionMode !== local.livePermissionMode;
@@ -263,7 +266,10 @@ export const WatchdogRescueSessionCard = () => {
                 loading=${working}
               />`
             : null}
-          ${state === "running" || state === "starting" || disabledWithLiveSession
+          ${state === "running" ||
+          state === "starting" ||
+          disabledWithLiveSession ||
+          retainedInError
             ? html`<${ActionButton}
                 onClick=${onStopClick}
                 tone="danger"

--- a/lib/server/claude-code-local/index.js
+++ b/lib/server/claude-code-local/index.js
@@ -386,6 +386,20 @@ const createClaudeCodeLocalService = ({
     return { installed: true, claudeVersion, loggedIn };
   };
 
+  // Auth-gate outcome → probe memo (F131): needs_login is an authoritative
+  // "not logged in"; any other gate leaves the memo alone (lastError shows it).
+  const applyAuthGateToProbe = (probe, gate) => {
+    if (!probe) return probe;
+    if (gate === "needs_login") return { ...probe, loggedIn: false };
+    return probe;
+  };
+  // The sessionId reconstructs the account-gated claude.ai URL canonically
+  // (tui.js) — the process log is agent-readable, so log a prefix only (F133).
+  const redactSessionId = (value) => {
+    const text = String(value || "");
+    return text.length > 8 ? `${text.slice(0, 8)}…` : text ? "…" : "(none)";
+  };
+
   const refreshProbes = ({ force = false } = {}) => {
     if (probeInFlight) return probeInFlight;
     if (!force && probeState && nowFn() - probeState.at < intervals.probeMs) {
@@ -584,6 +598,9 @@ const createClaudeCodeLocalService = ({
     }
     log(`session process died (${session.phase}) — reaping pane, back to ready`);
     await reapDeadTmuxSession().catch(() => {});
+    // The reap awaited; a start that landed meanwhile owns `session` now
+    // (fix wave F136) — never null a successor.
+    if (!session || session.generation !== gen) return;
     session = null;
     persistSession();
   };
@@ -661,7 +678,7 @@ const createClaudeCodeLocalService = ({
           session.sessionUrl = found.sessionUrl;
           lastError = null;
           persistSession();
-          log(`running — session ${found.sessionId} (${session.spawnedBy}, mode ${session.mode})`);
+          log(`running — session ${redactSessionId(found.sessionId)} (${session.spawnedBy}, mode ${session.mode})`);
           return;
         }
         if (detectWorkspaceNotTrusted(buffer)) {
@@ -696,8 +713,10 @@ const createClaudeCodeLocalService = ({
           if (session && session.generation === gen) {
             session = null;
             persistSession();
-            // The auth gate is authoritative: the login probe memo is stale.
-            probeState = null;
+            // The auth gate is authoritative: reflect it in the probe memo
+            // (fix wave F131). Nulling the memo collapsed the status to
+            // "probing" — hiding needs_login/error — until the 60s probe fired.
+            probeState = applyAuthGateToProbe(probeState, gate);
           }
           return;
         }
@@ -714,6 +733,8 @@ const createClaudeCodeLocalService = ({
       if (!session || session.generation !== gen) return;
       if (!liveness.alive) {
         await reapDeadTmuxSession().catch(() => {});
+        // The reap awaited (F136): a newer start may own `session` now.
+        if (!session || session.generation !== gen) return;
         setError(
           "spawn_failed",
           "The claude process exited before publishing a Remote Control URL.",
@@ -789,8 +810,17 @@ const createClaudeCodeLocalService = ({
         sessionUrl = found.sessionUrl;
       }
     }
+    // AlphaClaw restarted while the pane was still waiting for its Remote
+    // Control URL (fix wave F134): the pane is alive and identity-matched, and
+    // the URL budget has not elapsed — resume the watcher instead of marking
+    // a healthy session adopted_without_url.
+    const resumeUrlWait =
+      !sessionUrl &&
+      identityMatches &&
+      persisted?.phase === "starting" &&
+      nowFn() - Number(persisted?.startedAt || 0) < intervals.urlDeadlineMs;
     session = {
-      phase: sessionUrl ? "running" : "running_no_url",
+      phase: sessionUrl ? "running" : resumeUrlWait ? "starting" : "running_no_url",
       hosting: "tmux",
       mode: identityMatches ? persisted.mode || null : null,
       cwd: identityMatches ? persisted.cwd || null : null,
@@ -810,6 +840,13 @@ const createClaudeCodeLocalService = ({
       panePid: info.panePid,
       warnings: [],
     };
+    if (resumeUrlWait) {
+      lastError = null;
+      log(`adopted a rescue session still waiting for its URL (pane ${info.panePid}) — resuming the watcher`);
+      persistSession();
+      watchForUrl(gen).catch((error) => log(`url watcher (resumed) failed: ${error?.message || error}`));
+      return true;
+    }
     if (!sessionUrl) {
       const buffer = await driver.capturePane({ sessionName, lines: 800, env: rescueEnv });
       setError(
@@ -819,7 +856,7 @@ const createClaudeCodeLocalService = ({
       );
     } else {
       lastError = null;
-      log(`adopted live session ${sessionId} (pane ${info.panePid})`);
+      log(`adopted live session ${redactSessionId(sessionId)} (pane ${info.panePid})`);
     }
     persistSession();
     return true;
@@ -957,7 +994,7 @@ const createClaudeCodeLocalService = ({
           session.sessionId = found.sessionId;
           session.sessionUrl = found.sessionUrl;
           persistSession();
-          log(`running — session ${found.sessionId} (script hosting)`);
+          log(`running — session ${redactSessionId(found.sessionId)} (script hosting)`);
           return;
         }
         if (!rcConfirmAnswered && detectRemoteControlConfirm(session.buffer)) {
@@ -972,7 +1009,7 @@ const createClaudeCodeLocalService = ({
           killChild(session.proc);
           session = null;
           persistSession();
-          probeState = null;
+          probeState = applyAuthGateToProbe(probeState, gate);
           return;
         }
         // One-shot + deadline, mirroring the tmux watcher: the prompt text
@@ -1461,12 +1498,16 @@ const createClaudeCodeLocalService = ({
   const reconcileOnBoot = () => {
     (async () => {
       await refreshProbes({ force: true });
-      if (!isEnabled()) return;
+      // Adoption runs even when the feature is disabled (fix wave F135): it
+      // spawns nothing, and a still-live rescue session after an AlphaClaw
+      // restart must stay visible (warning, Stop, working /rescue link) —
+      // "disabling never kills a live session" is the documented contract.
       const adopted = await runExclusive("boot-reconcile", async ({ generation: gen }) => {
         if (!probeState?.tmuxOk) return false;
         return adoptSession({ gen });
       });
       if (adopted === true) return;
+      if (!isEnabled()) return;
       if (
         isAutostart() &&
         probeState?.installed &&

--- a/lib/server/claude-code-local/tmux.js
+++ b/lib/server/claude-code-local/tmux.js
@@ -60,12 +60,23 @@ const createTmuxDriver = ({
     rows = 50,
     env,
   }) => {
+    let created_warning = "";
     // history-limit applies only to windows created AFTER it is set, so the
     // GLOBAL default must be raised on the server BEFORE new-session creates
     // the rescue pane — a `set-option -t session` afterward leaves the (only)
     // pane at the 2000-line default and silently caps adoption re-extraction.
-    // This call also starts the server on our managed socket.
-    await run(["set-option", "-g", "history-limit", "50000"], { env });
+    // set-option is NOT a server-starting command (fix wave F132): issued
+    // against a socket with no server it fails silently and the pane was
+    // created at tmux's 2000-line default, making the 10k/50k scrollback
+    // escalation inert. start-server first, then raise the limit, then create.
+    const started = await run(["start-server"], { env });
+    if (started.code !== 0) return started;
+    const limited = await run(["set-option", "-g", "history-limit", "50000"], { env });
+    if (limited.code !== 0) {
+      // Not fatal — the session still works, only re-extraction depth suffers;
+      // surface it in the result so callers can log it.
+      created_warning = `history-limit not applied: ${limited.stderr || limited.code}`;
+    }
     const created = await run(
       [
         "new-session",
@@ -84,6 +95,7 @@ const createTmuxDriver = ({
       { env },
     );
     if (created.code !== 0) return created;
+    if (created_warning) created.warning = created_warning;
     // remain-on-exit keeps the death screen capturable — a fast CLI exit
     // would otherwise destroy the only pane, kill the single-session server,
     // and take the diagnostics with it (observed live during the T0 spike).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.83",
+  "version": "0.9.84",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "alphaclaw",
-      "version": "0.9.83",
+      "version": "0.9.84",
       "license": "MIT",
       "dependencies": {
         "compression": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alphaclaw",
-  "version": "0.9.83",
+  "version": "0.9.84",
   "publishConfig": {
     "access": "public"
   },

--- a/tests/frontend/rescue-session-card.test.js
+++ b/tests/frontend/rescue-session-card.test.js
@@ -329,6 +329,29 @@ describe("WatchdogRescueSessionCard render states", () => {
     expect(buttonLabels(tree)).toContain("Retry start");
   });
 
+  it("error with a RETAINED live session renders Stop next to Retry (F130)", () => {
+    // running_no_url / adopted_without_url keep the pane for diagnosis and the
+    // server copy says "then Stop to retry" — Stop must actually be there.
+    const tree = renderCard(
+      baseLocal({
+        state: "error",
+        startedAt: Date.now() - 30_000,
+        error: {
+          code: "url_extract_timeout",
+          message: "No Remote Control URL after 90s — the session is kept for diagnosis (view the output tail, then Stop to retry).",
+          tailSanitized: "raw tail",
+        },
+      }),
+    );
+    const labels = buttonLabels(tree);
+    expect(labels).toContain("Stop session");
+    expect(labels).toContain("Retry start");
+    // A plain error with no retained session keeps the old shape.
+    const plain = buttonLabels(renderCard(baseLocal({ state: "error", startedAt: null, error: { code: "spawn_failed", message: "x" } })));
+    expect(plain).not.toContain("Stop session");
+    expect(plain).toContain("Retry start");
+  });
+
   it("disabled with a live session collapses to stop-only", () => {
     // E2: the kill switch hides the launch path but must never cut off an
     // operator mid-rescue.

--- a/tests/server/claude-code-local-service.test.js
+++ b/tests/server/claude-code-local-service.test.js
@@ -1260,3 +1260,147 @@ describe("claude-code-local service", () => {
     });
   });
 });
+
+
+describe("claude-code-local service — fix wave PR 10 (F131, F133, F134, F135)", () => {
+  const kBanner =
+    "Continue coding in the Claude mobile app or https://claude.ai/code?environment=env_01REALBANNER";
+
+  const buildService = ({ env = {}, driver, fsModule, timers } = {}) => {
+    const fakeDriver = driver || createFakeDriver();
+    const fakeFs = fsModule || createFakeFs();
+    const logger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
+    const service = createClaudeCodeLocalService({
+      env,
+      fsModule: fakeFs,
+      tmux: fakeDriver,
+      runStream: createFakeRunStream(),
+      logger,
+      paths: kPaths,
+      timers: timers || kFastTimers,
+    });
+    return { service, driver: fakeDriver, fsModule: fakeFs, logger };
+  };
+
+  it("the auth gate reports needs_login IMMEDIATELY instead of collapsing to probing (F131)", async () => {
+    const { service, driver } = buildService({});
+    await service.refreshProbes({ force: true });
+    await service.startSession({ confirmed: true, source: "click" });
+    driver.state.buffer =
+      "Error: You must be logged in to use Remote Control.\nRemote Control is only available with claude.ai subscriptions.";
+    await flush(60);
+    const snapshot = service.getStatusSnapshot();
+    expect(snapshot.state).toBe("needs_login");
+    expect(snapshot.state).not.toBe("probing");
+    expect(driver.killSession).toHaveBeenCalled();
+  });
+
+  it("never writes the full Remote Control sessionId to the process log (F133)", async () => {
+    const { service, driver, logger } = buildService({});
+    await service.refreshProbes({ force: true });
+    await service.startSession({ confirmed: true, source: "click" });
+    driver.state.buffer = "https://claude.ai/code/sess_abcdef123456SECRETTAIL";
+    await flush(60);
+    expect(service.getStatusSnapshot().state).toBe("running");
+    const logged = logger.log.mock.calls.map((call) => String(call[0])).join("\n");
+    expect(logged).toMatch(/running — session sess_abc…/);
+    expect(logged).not.toContain("sess_abcdef123456SECRETTAIL");
+  });
+
+  it("boot adoption RESUMES the URL wait for a pane persisted as `starting` (F134)", async () => {
+    const { driver, fsModule } = buildService({});
+    driver.state.sessionAlive = true;
+    driver.state.panePid = 4242;
+    driver.state.buffer = "claude is starting up…"; // no URL yet
+    fsModule.files.set(
+      kPaths.stateFile,
+      JSON.stringify({
+        sessionName: "alphaclaw-rescue",
+        phase: "starting",
+        hosting: "tmux",
+        panePid: 4242,
+        startedAt: Date.now() - 1_000,
+        spawnedBy: "click",
+        mode: "acceptEdits",
+      }),
+    );
+    const { service } = buildService({ driver, fsModule, timers: { ...kFastTimers, urlDeadlineMs: 5_000 } });
+    service.reconcileOnBoot();
+    await flush(60);
+    // Healthy pane inside its URL budget: still starting, NOT adopted_without_url.
+    let snapshot = service.getStatusSnapshot();
+    expect(snapshot.state).toBe("starting");
+    expect(snapshot.error).toBeFalsy();
+    // The URL appears: the resumed watcher promotes the session to running.
+    driver.state.buffer = kBanner;
+    await flush(80);
+    snapshot = service.getStatusSnapshot();
+    expect(snapshot.state).toBe("running");
+    expect(snapshot.sessionUrl).toMatch(/^\/rescue\/[0-9a-f]{64}$/);
+  });
+
+  it("boot adoption still marks a pane adopted_without_url when its URL budget has elapsed (F134 bound)", async () => {
+    const { driver, fsModule } = buildService({});
+    driver.state.sessionAlive = true;
+    driver.state.panePid = 4242;
+    driver.state.buffer = "no url here";
+    fsModule.files.set(
+      kPaths.stateFile,
+      JSON.stringify({
+        sessionName: "alphaclaw-rescue",
+        phase: "starting",
+        hosting: "tmux",
+        panePid: 4242,
+        startedAt: Date.now() - 10 * 60_000,
+      }),
+    );
+    const { service } = buildService({ driver, fsModule, timers: { ...kFastTimers, urlDeadlineMs: 5_000 } });
+    service.reconcileOnBoot();
+    await flush(60);
+    const snapshot = service.getStatusSnapshot();
+    expect(snapshot.state).toBe("error");
+    expect(snapshot.error.code).toBe("adopted_without_url");
+  });
+
+  it("boot adoption runs while the feature is DISABLED so a live session stays visible and stoppable (F135)", async () => {
+    const { driver, fsModule } = buildService({});
+    driver.state.sessionAlive = true;
+    driver.state.panePid = 4242;
+    driver.state.buffer = kBanner;
+    fsModule.files.set(
+      kPaths.stateFile,
+      JSON.stringify({
+        sessionName: "alphaclaw-rescue",
+        phase: "running",
+        hosting: "tmux",
+        panePid: 4242,
+        startedAt: Date.now() - 60_000,
+        sessionUrl: "https://claude.ai/code?environment=env_01REALBANNER",
+      }),
+    );
+    const env = { CLAUDE_CODE_LOCAL_ENABLED: "0" };
+    const { service } = buildService({ env, driver, fsModule });
+    service.reconcileOnBoot();
+    await flush(60);
+    const snapshot = service.getStatusSnapshot();
+    expect(snapshot.state).toBe("disabled");
+    expect(snapshot.startedAt).toBeTruthy();
+    expect(snapshot.warnings.join(" ")).toContain("still live");
+    // Disabled still means "no new spawns": autostart did not fire, nothing was killed.
+    expect(driver.newSession).not.toHaveBeenCalled();
+    expect(driver.killSession).not.toHaveBeenCalled();
+    // Re-enabling (hot-reloaded .env) reveals the adopted session with a
+    // working revocable link — proof the adoption really happened.
+    env.CLAUDE_CODE_LOCAL_ENABLED = "";
+    const live = service.getStatusSnapshot();
+    expect(live.state).toBe("running");
+    expect(live.sessionUrl).toMatch(/^\/rescue\/[0-9a-f]{64}$/);
+    expect(
+      service.resolveRescueRedirect(live.sessionUrl.slice("/rescue/".length)),
+    ).toBe("https://claude.ai/code?environment=env_01REALBANNER");
+    env.CLAUDE_CODE_LOCAL_ENABLED = "0";
+    const stopped = await service.stopSession();
+    expect(stopped.ok).toBe(true);
+    expect(driver.killSession).toHaveBeenCalled();
+  });
+});

--- a/tests/server/claude-code-local-tmux.test.js
+++ b/tests/server/claude-code-local-tmux.test.js
@@ -94,20 +94,25 @@ describe("claude-code-local tmux driver", () => {
         env: kEnv,
       });
       expect(result.code).toBe(0);
-      expect(execFileImpl).toHaveBeenCalledTimes(3);
+      expect(result.warning).toBeUndefined();
+      expect(execFileImpl).toHaveBeenCalledTimes(4);
       expect(execFileImpl.mock.calls[0][0]).toBe("tmux");
-      // history-limit is raised GLOBALLY first (before the pane exists) so the
+      // The server must exist before set-option can land (fix wave F132):
+      // set-option is not a server-starting command and failed silently,
+      // leaving the pane at tmux's 2000-line default.
+      expect(execFileImpl.mock.calls[0][1]).toEqual([...kSocketPrefix, "start-server"]);
+      // The scrubbed env must reach the server-starting call too.
+      expect(execFileImpl.mock.calls[0][2].env).toBe(kEnv);
+      // history-limit is raised GLOBALLY next (before the pane exists) so the
       // rescue pane inherits it — a -t session set afterward would not apply.
-      expect(execFileImpl.mock.calls[0][1]).toEqual([
+      expect(execFileImpl.mock.calls[1][1]).toEqual([
         ...kSocketPrefix,
         "set-option",
         "-g",
         "history-limit",
         "50000",
       ]);
-      // The scrubbed env must reach the server-starting call too.
-      expect(execFileImpl.mock.calls[0][2].env).toBe(kEnv);
-      expect(execFileImpl.mock.calls[1][1]).toEqual([
+      expect(execFileImpl.mock.calls[2][1]).toEqual([
         ...kSocketPrefix,
         "new-session",
         "-d",
@@ -122,7 +127,7 @@ describe("claude-code-local tmux driver", () => {
         "--",
         ...kCommandArgv,
       ]);
-      expect(execFileImpl.mock.calls[2][1]).toEqual([
+      expect(execFileImpl.mock.calls[3][1]).toEqual([
         ...kSocketPrefix,
         "set-option",
         "-t",
@@ -130,6 +135,38 @@ describe("claude-code-local tmux driver", () => {
         "remain-on-exit",
         "on",
       ]);
+    });
+
+    it("surfaces a failed history-limit as a warning and stops early when the server cannot start (F132)", async () => {
+      const limitFails = createDriver((args) =>
+        args.includes("history-limit")
+          ? { error: kExitOneError("bad option"), stderr: "unknown option: history-limit" }
+          : { code: 0 },
+      );
+      const limited = await limitFails.driver.newSession({
+        sessionName: kSessionName,
+        cwd: kWorkspace,
+        commandArgv: kCommandArgv,
+        env: kEnv,
+      });
+      expect(limited.code).toBe(0);
+      expect(limited.warning).toMatch(/history-limit not applied/);
+      // start-server, set-option, new-session, remain-on-exit still ran.
+      expect(limitFails.execFileImpl).toHaveBeenCalledTimes(4);
+
+      const serverFails = createDriver((args) =>
+        args.includes("start-server")
+          ? { error: kExitOneError("no socket"), stderr: "error connecting" }
+          : { code: 0 },
+      );
+      const failed = await serverFails.driver.newSession({
+        sessionName: kSessionName,
+        cwd: kWorkspace,
+        commandArgv: kCommandArgv,
+        env: kEnv,
+      });
+      expect(failed.code).toBe(1);
+      expect(serverFails.execFileImpl).toHaveBeenCalledTimes(1);
     });
 
     it("skips remain-on-exit when creation fails", async () => {
@@ -145,8 +182,9 @@ describe("claude-code-local tmux driver", () => {
         env: kEnv,
       });
       expect(result.code).toBe(1);
-      // global set-option + failed new-session, but NO remain-on-exit follow-up.
-      expect(execFileImpl).toHaveBeenCalledTimes(2);
+      // start-server + global set-option + failed new-session, but NO
+      // remain-on-exit follow-up.
+      expect(execFileImpl).toHaveBeenCalledTimes(3);
     });
   });
 


### PR DESCRIPTION
Fix wave, PR 10 of the sequence (stacked on #71 → #70 → #69 → #68 → #67 → #66 → #65 → #63 → #62 → #61 → #60; merges into `kolkata-v4-pr9b`). Audit batch 26: local Claude Code rescue session. Version **0.9.84**.

## What changed

- **F130 (P2)** — `rescue-session-card.js`: the Error state hid Stop even when a live session was retained (`running_no_url` / `adopted_without_url`), while the server copy said "view the output tail, then Stop to retry". Stop renders for any retained session (`state === "error" && startedAt`); a plain error keeps the old shape.
- **F131 (P2)** — the auth-gate branches nulled `probeState`, so the status guard table collapsed to `probing` (hiding `needs_login`/`error`) until the 60s probe timer fired. `applyAuthGateToProbe` marks the memo `loggedIn: false` for the `needs_login` gate and leaves it alone otherwise; the status is honest immediately.
- **F132 (P2)** — `tmux.js newSession`: `set-option -g history-limit 50000` ran against a socket with no server yet (set-option does not start one) and failed silently, so the rescue pane was created at tmux's 2000-line default and adoption's 10k/50k re-extraction escalation was inert. `start-server` runs first (its failure returns early); a failed limit is surfaced as `result.warning`. Tests pin the call order (start-server → set-option → new-session → remain-on-exit).
- **F133** — the raw Remote Control `sessionId` (which reconstructs the account-gated claude.ai URL canonically) no longer appears in the agent-readable process log (`redactSessionId`: 8-char prefix).
- **F134 (P2)** — boot adoption ignored the persisted `starting` phase: an AlphaClaw restart during the URL-wait window marked a healthy pane `adopted_without_url` and never resumed the watcher. An identity-matched pane whose persisted phase is `starting` and whose URL budget has not elapsed resumes `watchForUrl` (fresh deadline; noted in code).
- **F135** — `reconcileOnBoot` skipped adoption when `CLAUDE_CODE_LOCAL_ENABLED=0`, so a still-live session after a restart was invisible (no warning, no Stop, 404 rescue link) despite the documented "disabling never kills a live session". Adoption (read-only) runs regardless; only autostart stays gated.
- **F136** — `checkSessionLiveness` and the URL watcher's dead-pane branch re-check the session generation after the reap `await` before nulling `session`, so a start that landed meanwhile is never cleared. Covered by review (the race needs a hand-timed reap in the harness); the generation pattern matches the existing guards two lines above.

## Overlap / reconciliation
No open PR touches `lib/server/claude-code-local/*`, `routes/claude-code.js`, or the rescue card. `origin/main` is still v0.9.72; renumber in the final pre-merge commit if that changes.

## Supersedes recent work
- **#51 (v0.9.66, revocable rescue links)** and **#52 (v0.9.67)** touched `claude-code-local/index.js`; this PR extends adoption/liveness/auth-gate branches and redacts log lines — nothing from those PRs is removed.

## Verification
- `npm test` (Node 22, sandbox `OPENCLAW_*` env unset): see the final run noted in the PR conversation.
- Extended: `claude-code-local-tmux` (call order + F132 warning/early return), `rescue-session-card` (F130), `claude-code-local-service` (F131 immediate needs_login, F134 resumed URL wait, F135 adoption while disabled, F133 redacted log).
- Container tier not runnable here (no Docker); CI's Container E2E runs on this PR (the image carries tmux + the pinned claude CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- conductor-workspace-link -->

---

[Open workspace in Conductor](https://app.conductor.build/workspace/897cdaac-c48b-433c-8ab5-3f1ca0b5fe30)
