### PR TITLE
fix(auth-profiles): read/write the shared auth store from config_machine_state on state schema >= 13

### DIFF
--- a/lib/server/auth-profiles.js
+++ b/lib/server/auth-profiles.js
@@ -241,6 +241,120 @@ const saveSqliteAuthStore = (agentId, store) => {
 // consistency. Same BEGIN IMMEDIATE pattern as the agent-db writer below.
 const kSharedAuthRowKey = "shared";
 
+// ── KV layout of the same shared store ──────────────────────────────────────
+//
+// openclaw's v13 state migration copies auth_profile_stores/auth_profile_state
+// row 'shared' into config_machine_state rows 'authProfiles.store' /
+// 'authProfiles.state' and then DROPs both tables. The JSON shapes and the
+// single-writer contract are unchanged — only the row container moved — so
+// both layouts map onto the same { version, profiles, order, lastGood,
+// usageStats } store this module already speaks. auth.sharedStore stays the
+// sole authority for WHICH store is live; this only picks the container.
+const kSharedAuthKvStoreKey = "authProfiles.store";
+const kSharedAuthKvStateKey = "authProfiles.state";
+// The migration that relocates the rows is gated on user_version < 13, so the
+// DB's own schema version records whether it has run. Deliberately NOT decided
+// by which table or row exists: a table can be absent because the schema drifted
+// and a row can be absent because the store is legitimately empty, and guessing
+// the container from data risks writing where openclaw never reads.
+const kSharedAuthKvMinStateSchema = 13;
+
+const readStateSchemaVersion = (database) => {
+  const row = database.prepare("PRAGMA user_version").get();
+  const value = row ? Number(Object.values(row)[0]) : Number.NaN;
+  return Number.isInteger(value) && value > 0 ? value : null;
+};
+
+// Which container the state DB actually keeps the shared store in.
+// "kv" | "beta" | "unsupported" — the last one is fail-closed for both paths.
+const resolveSharedAuthContainer = (database) => {
+  const schema = readStateSchemaVersion(database);
+  if (schema === null) return "unsupported";
+  if (schema >= kSharedAuthKvMinStateSchema) {
+    return tableHasColumns(database, "config_machine_state", [
+      "state_key",
+      "value_json",
+      "updated_at_ms",
+    ])
+      ? "kv"
+      : "unsupported";
+  }
+  return tableHasColumns(database, "auth_profile_stores", [
+    "store_key",
+    "store_json",
+    "updated_at",
+  ]) &&
+    tableHasColumns(database, "auth_profile_state", ["store_key", "state_json", "updated_at"])
+    ? "beta"
+    : "unsupported";
+};
+
+// A stored cell must be a JSON object. Anything else (array, scalar, null,
+// empty string) is corruption, not an empty store: throwing here keeps it a
+// READ FAILURE so a strict mutator refuses instead of persisting a near-empty
+// store over live credentials. Arrays matter specifically — JSON.stringify
+// drops named properties added to an array, so a profiles:[] would swallow
+// every credential written to it.
+const parseSharedAuthCell = (raw, stateKey) => {
+  if (raw === undefined || raw === null) return {};
+  if (typeof raw !== "string" || raw.trim() === "") {
+    throw new Error(`shared auth cell ${stateKey} is empty or not text`);
+  }
+  const parsed = JSON.parse(raw);
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`shared auth cell ${stateKey} is not a JSON object`);
+  }
+  return parsed;
+};
+
+const readSharedAuthKvCell = (database, stateKey) =>
+  database
+    .prepare("SELECT value_json FROM config_machine_state WHERE state_key = ?")
+    .get(stateKey)?.value_json;
+
+// Caller wraps this in the same try/catch that maps a throw to { ok: false },
+// so a corrupt cell stays a READ FAILURE and never reads as "empty".
+const loadSharedAuthStoreFromKv = (database) => {
+  const secrets = parseSharedAuthCell(
+    readSharedAuthKvCell(database, kSharedAuthKvStoreKey),
+    kSharedAuthKvStoreKey,
+  );
+  const state = parseSharedAuthCell(
+    readSharedAuthKvCell(database, kSharedAuthKvStateKey),
+    kSharedAuthKvStateKey,
+  );
+  const profiles = secrets.profiles === undefined ? {} : secrets.profiles;
+  if (profiles === null || typeof profiles !== "object" || Array.isArray(profiles)) {
+    throw new Error(`shared auth cell ${kSharedAuthKvStoreKey} has a non-object profiles map`);
+  }
+  return {
+    ok: true,
+    store: {
+      version: Number(secrets.version || state.version || 1),
+      profiles,
+      order: state.order,
+      lastGood: state.lastGood,
+      usageStats: state.usageStats,
+    },
+  };
+};
+
+const saveSharedAuthStoreToKv = (database, secrets, state, now) => {
+  const write = database.prepare(
+    `INSERT INTO config_machine_state (state_key, value_json, updated_at_ms)
+     VALUES (?, ?, ?)
+     ON CONFLICT(state_key) DO UPDATE SET
+       value_json = excluded.value_json,
+       updated_at_ms = excluded.updated_at_ms`,
+  );
+  database.exec("BEGIN IMMEDIATE");
+  write.run(kSharedAuthKvStoreKey, JSON.stringify(secrets), now);
+  write.run(kSharedAuthKvStateKey, JSON.stringify(state), now);
+  database.exec("COMMIT");
+  return true;
+};
+
+
 // Returns { ok: true, store } — where an EMPTY store is a legitimate,
 // successful read — or { ok: false } when the db could not be read (lock,
 // corruption, schema drift). The distinction is load-bearing: conflating a
@@ -255,12 +369,12 @@ const loadSharedAuthStore = () => {
     // Tracked + busy_timeout-armed: a concurrent gateway holding the write
     // lock stalls this read briefly instead of failing it.
     database = openTrackedReadonlyDatabase(databasePath);
-    if (
-      !tableHasColumns(database, "auth_profile_stores", ["store_key", "store_json"]) ||
-      !tableHasColumns(database, "auth_profile_state", ["store_key", "state_json"])
-    ) {
-      return { ok: false };
-    }
+    const container = resolveSharedAuthContainer(database);
+    // "unsupported" is a read FAILURE, never an empty store: the caller's
+    // strict path must throw rather than let a mutator persist a near-empty
+    // store over live credentials.
+    if (container === "kv") return loadSharedAuthStoreFromKv(database);
+    if (container !== "beta") return { ok: false };
     const secretsRow = database
       .prepare("SELECT store_json FROM auth_profile_stores WHERE store_key = ?")
       .get(kSharedAuthRowKey);
@@ -293,13 +407,6 @@ const saveSharedAuthStore = (store) => {
     opened = openWritableOpenclawStateDb({ openclawDir: OPENCLAW_DIR });
     if (!opened) return false;
     const database = opened.db;
-    if (
-      !tableHasColumns(database, "auth_profile_stores", ["store_key", "store_json", "updated_at"]) ||
-      !tableHasColumns(database, "auth_profile_state", ["store_key", "state_json", "updated_at"])
-    ) {
-      // Schema drift: fail closed rather than write a shape openclaw ignores.
-      return false;
-    }
     const now = Date.now();
     const secrets = {
       version: Number(store.version || 1),
@@ -311,6 +418,14 @@ const saveSharedAuthStore = (store) => {
       ...(store.lastGood !== undefined ? { lastGood: store.lastGood } : {}),
       ...(store.usageStats !== undefined ? { usageStats: store.usageStats } : {}),
     };
+    const container = resolveSharedAuthContainer(database);
+    if (container === "kv") return saveSharedAuthStoreToKv(database, secrets, state, now);
+    // Fail closed on "unsupported": never write a shape the installed openclaw
+    // ignores. NOTE: this write is still not atomic with the caller's read —
+    // openclaw can refresh a token in between and this overwrites it. That race
+    // predates the KV layout (the beta writer below has it too) and needs a
+    // read-modify-write inside one transaction to fix properly.
+    if (container !== "beta") return false;
     database.exec("BEGIN IMMEDIATE");
     database
       .prepare(


### PR DESCRIPTION
Fixes the shared-auth-store breakage reported in #88.

OpenClaw's v13 state migration moves the shared auth store out of the
`auth_profile_stores` / `auth_profile_state` tables into `config_machine_state` KV rows
and then `DROP`s both tables. `loadSharedAuthStore()` / `saveSharedAuthStore()` still probe
only the old tables, so on a box at `user_version >= 13` the table-existence guard fails:
the lenient read returns an empty store (Codex reads as disconnected while the credential
is intact) and the strict read throws, which fails both re-auth and disconnect.

Three design points, in case they are worth arguing about:

- **The container is chosen by `PRAGMA user_version`, not by which table or row exists.**
  A table can be absent because the schema drifted, and a row can be absent because the
  store is legitimately empty, so inferring the container from data risks writing where
  OpenClaw never reads. Unrecognised schema is fail-closed for both read and write.
- **A malformed cell is a read failure, not an empty store.** An absent row is legitimately
  empty, but an empty string, a scalar, `null` or an array throws, so the strict path
  refuses instead of letting a mutator persist a near-empty store over live credentials.
- **`profiles` is checked to be a plain object specifically.** `JSON.stringify` drops named
  properties assigned to an array, so a `profiles: []` would otherwise be silently
  persisted over every credential by a write that appeared to succeed.

Known defects this does NOT fix are listed in #88 — chiefly the inherited lost-update
window (the read uses a separate connection; `BEGIN IMMEDIATE` covers only the two
UPSERTs), which predates this change.

**Verification.** Applies cleanly on `d2c991d` (current `main` tip). A self-contained
harness against a synthetic STRICT `config_machine_state` DB at `user_version 16` passes
10/10: round-trip, order/lastGood preservation, no clobber of an existing profile, and
empty-string / `false` / `42` / `[]` / truncated JSON / `{"profiles":[]}` each rejected as
a read failure. That harness re-implements the logic rather than importing the shipped
file, so treat it as a check on the algorithm.

Running on one box (AlphaClaw 0.9.82 + OpenClaw 2026.9.3) where it restored
`connected: true`. Not exercised against a live OAuth exchange, a live disconnect, the
Models routes, or concurrent OpenClaw writes — please treat as a candidate rather than as
proven in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
