### PR TITLE
fix(proxy): forward the A2A endpoint and Agent Card to the gateway (enabled A2A channel is unreachable through AlphaClaw)

### DIFF
--- a/lib/server/routes/proxy.js
+++ b/lib/server/routes/proxy.js
@@ -386,8 +386,16 @@ const registerProxyRoutes = ({
   // forwardToGateway still strips inbound identity headers and the setup
   // cookie and enforces the streamed body cap, so an unauthenticated caller
   // reaches the gateway's own A2A auth and nothing else.
-  app.all(kA2aPathPattern, (req, res) => forwardToGateway(req, res));
-  app.all(kAgentCardPathPattern, (req, res) => forwardToGateway(req, res));
+  // rejectUnsafePath applies here too: an unauthenticated route must not be
+  // the one place a traversal or bad-encoding path reaches the gateway.
+  app.all(kA2aPathPattern, (req, res) => {
+    if (rejectUnsafePath(req, res)) return;
+    forwardToGateway(req, res);
+  });
+  app.all(kAgentCardPathPattern, (req, res) => {
+    if (rejectUnsafePath(req, res)) return;
+    forwardToGateway(req, res);
+  });
 
   app.all("/oauth/:id", oauthCallbackMiddleware);
   app.all(kHooksPathPattern, webhookMiddleware);

--- a/lib/server/routes/proxy.js
+++ b/lib/server/routes/proxy.js
@@ -199,6 +199,17 @@ const proxyOpenAiCompatRequest = ({
 const kOpenClawPathPattern = /^\/openclaw(?:\/.*)?$/;
 const kAssetsPathPattern = /^\/assets\/.+/;
 
+// A2A is a gateway-served channel whose auth is a per-peer bearer token that
+// the gateway validates itself, so these paths forward WITHOUT requireAuth and
+// without the gateway-token equality the /v1 compat proxy enforces — imposing
+// either would reject a valid peer before the gateway ever sees it. Agent Card
+// discovery is public by design ("Agent Card discovery is intentionally
+// public", openclaw docs/channels/a2a.md). Without these routes an enabled A2A
+// channel is unreachable through the front door: the gateway listens on
+// container loopback only, so it cannot be published around this proxy.
+const kA2aPathPattern = /^\/a2a\/.+/;
+const kAgentCardPathPattern = /^\/\.well-known\/agent(?:-card)?\.json$/;
+
 // Local /api namespaces that are NOT in SETUP_API_PREFIXES (the catch-all
 // proxy's list) but ARE served by locally-registered routes, which need
 // parsed bodies. The parser-skip predicate below must treat them as local.
@@ -238,6 +249,8 @@ const createIsProxiedPath = (setupApiPrefixes = []) => {
     if (requestPath === "/openclaw") return true;
     if (kOpenClawPathPattern.test(requestPath)) return true;
     if (kAssetsPathPattern.test(requestPath)) return true;
+    if (kA2aPathPattern.test(requestPath)) return true;
+    if (kAgentCardPathPattern.test(requestPath)) return true;
     if (/^\/api\/.+/.test(requestPath)) {
       return !localPrefixes.some((prefix) =>
         matchesApiPrefixSegment(requestPath, prefix),
@@ -368,6 +381,14 @@ const registerProxyRoutes = ({
     forwardToGateway(req, res);
   });
 
+  // Deliberately no requireAuth: the A2A peer credential IS the caller's
+  // identity, and the gateway is the only component that can validate it.
+  // forwardToGateway still strips inbound identity headers and the setup
+  // cookie and enforces the streamed body cap, so an unauthenticated caller
+  // reaches the gateway's own A2A auth and nothing else.
+  app.all(kA2aPathPattern, (req, res) => forwardToGateway(req, res));
+  app.all(kAgentCardPathPattern, (req, res) => forwardToGateway(req, res));
+
   app.all("/oauth/:id", oauthCallbackMiddleware);
   app.all(kHooksPathPattern, webhookMiddleware);
   app.all(kWebhookPathPattern, webhookMiddleware);
@@ -396,6 +417,8 @@ const registerProxyRoutes = ({
 
 module.exports = {
   kOpenAiCompatProxyPathPattern,
+  kA2aPathPattern,
+  kAgentCardPathPattern,
   createIsProxiedPath,
   registerProxyRoutes,
   // Exported for tests.

--- a/tests/server/proxy-a2a-paths.test.js
+++ b/tests/server/proxy-a2a-paths.test.js
@@ -1,4 +1,3 @@
-const { describe, it, expect } = require("vitest");
 const {
   kA2aPathPattern,
   kAgentCardPathPattern,

--- a/tests/server/proxy-a2a-paths.test.js
+++ b/tests/server/proxy-a2a-paths.test.js
@@ -1,0 +1,55 @@
+const { describe, it, expect } = require("vitest");
+const {
+  kA2aPathPattern,
+  kAgentCardPathPattern,
+  createIsProxiedPath,
+} = require("../../lib/server/routes/proxy");
+
+// The gateway listens on container loopback only, so the front-door proxy is
+// the sole route to an enabled A2A channel. These paths must both match a
+// forwarding route and be treated as proxied paths, or the body parser
+// consumes the JSON-RPC request and the gateway hangs on an empty stream.
+describe("A2A proxy paths", () => {
+  const isProxiedPath = createIsProxiedPath(["/api/setup"]);
+  const proxied = (path) => isProxiedPath({ path });
+
+  it("matches the documented JSON-RPC endpoint", () => {
+    expect(kA2aPathPattern.test("/a2a/v1")).toBe(true);
+    expect(proxied("/a2a/v1")).toBe(true);
+  });
+
+  it("matches both Agent Card discovery spellings", () => {
+    // docs/channels/a2a.md serves the modern name and keeps agent.json for
+    // older A2A clients.
+    expect(kAgentCardPathPattern.test("/.well-known/agent-card.json")).toBe(true);
+    expect(kAgentCardPathPattern.test("/.well-known/agent.json")).toBe(true);
+    expect(proxied("/.well-known/agent-card.json")).toBe(true);
+    expect(proxied("/.well-known/agent.json")).toBe(true);
+  });
+
+  // Negative controls: the patterns must not widen the proxied surface.
+  it("does not match a bare or look-alike a2a path", () => {
+    expect(kA2aPathPattern.test("/a2a")).toBe(false);
+    expect(kA2aPathPattern.test("/a2away/v1")).toBe(false);
+    expect(proxied("/a2a")).toBe(false);
+  });
+
+  it("does not match other well-known paths", () => {
+    expect(kAgentCardPathPattern.test("/.well-known/openid-configuration")).toBe(
+      false,
+    );
+    expect(kAgentCardPathPattern.test("/.well-known/agent-card.json.bak")).toBe(
+      false,
+    );
+    expect(proxied("/.well-known/openid-configuration")).toBe(false);
+  });
+
+  it("leaves the existing predicate behaviour intact", () => {
+    expect(proxied("/openclaw")).toBe(true);
+    expect(proxied("/openclaw/anything")).toBe(true);
+    expect(proxied("/assets/app.js")).toBe(true);
+    expect(proxied("/api/gateway/restart")).toBe(true);
+    expect(proxied("/api/setup/status")).toBe(false);
+    expect(proxied("/login.html")).toBe(false);
+  });
+});


### PR DESCRIPTION
An enabled A2A channel cannot be reached through AlphaClaw.

## Symptom

Observed on AlphaClaw 0.9.82 + OpenClaw 2026.9.3, with `channels.a2a` enabled and one peer
configured. From inside the container, against the gateway directly:

```
GET  http://127.0.0.1:18789/.well-known/agent-card.json   -> 200
POST http://127.0.0.1:18789/a2a/v1   (no auth)            -> 401
```

The channel is loaded and demanding a peer token, exactly as it should. The same two paths
through AlphaClaw on port 3000 return **404**, from inside the container as well as from the
host.

## Why the port cannot simply be published instead

The gateway binds container loopback only — `/proc/net/tcp` shows `127.0.0.1:18789` and
`/proc/net/tcp6` shows `::1`. Publishing 18789 in compose forwards to the container's external
interface, where nothing is listening, so the front-door proxy is not merely the preferred route
to an A2A channel, it is the only one.

## Cause

`lib/server/routes/proxy.js` forwards a request only when the path is exactly `/openclaw`,
matches `kOpenClawPathPattern` or `kAssetsPathPattern`, or begins `/api/` and is not a local-only
prefix. `/v1/*` reaches the gateway through its own compat handler rather than this table.
`/a2a/v1` and `/.well-known/agent-card.json` match none of them.

This generalises: any OpenClaw channel that serves its own HTTP paths becomes unreachable
through AlphaClaw once enabled, because the path set here is fixed.

## The change

Registers both patterns to `forwardToGateway` and adds them to `createIsProxiedPath`.

The predicate entry is load-bearing rather than cosmetic. The comment already in that file warns
that a proxied path's body must not be consumed by a parser, *"a parsed stream reaches the
gateway empty and the request hangs until the gateway gives up"* — A2A is JSON-RPC over POST, so
without the predicate entry the endpoint would route and then hang.

**On the deliberate absence of `requireAuth` on these two routes**, since that is the part worth
arguing about:

- The A2A peer credential *is* the caller's identity, and the gateway is the only component that
  can validate it. Requiring a setup session would lock out every peer the feature exists for.
- Reusing the `/v1` handler was also wrong: it enforces equality with the gateway token
  (`timingSafeStringEqual(bearerToken, expectedGatewayToken)`), which would reject a valid peer
  token before the gateway ever saw it.
- `forwardToGateway` still enforces the streamed body cap and still strips inbound identity
  headers and the setup cookie via `applyProxyIdentity`, so an unauthenticated caller reaches the
  gateway's own A2A auth and nothing else.
- Agent Card discovery is public by design — openclaw `docs/channels/a2a.md`: *"Agent Card
  discovery is intentionally public: anyone who can reach the gateway can read the instance
  description and exposed agent IDs."* That page also points operators at `exposeAgents` and
  HTTPS for untrusted networks.

## Tests

`tests/server/proxy-a2a-paths.test.js` covers both spellings of the card (`agent-card.json` and
the `agent.json` alias older A2A clients use), the JSON-RPC endpoint, negative controls (`/a2a`,
`/a2away/v1`, `/.well-known/openid-configuration`, `agent-card.json.bak`), and a regression check
that `/openclaw`, `/assets/*`, `/api/*` and the local-prefix exclusion are unchanged.

Verified against the predicate directly: 11/11, including the negative controls. I have not run
the full `vitest run` suite in this environment, so please treat the suite result as unverified
by me.

## Not covered here

With the gateway behind this proxy, `channels.a2a.advertisedUrl` should be set to the externally
reachable origin or the Agent Card advertises the gateway's own origin. That is operator
configuration rather than a code fix, so it is out of scope for this PR, but it is the next thing
an operator hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
